### PR TITLE
[codex] Add readable market-pulse Codex aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ mp research "금리 하락이 성장주에 좋은 신호임?"
 mp "대형 IPO 때문에 성장주가 강한 걸까?" --research
 mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 mp now
+mp regime
 mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
 mp review
 ```
@@ -133,6 +134,20 @@ Live quotes are fetched through the Yahoo Finance chart endpoint by shelling out
 
 `mp now` is a session/daily pulse, not a weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `regularMarketPrice` versus `chartPreviousClose` from `range=5d&interval=1d` — usually the prior regular-session close for that asset. Because assets trade in different time zones, treat the card as a cross-asset snapshot and use `$mp-research` when the exact session calendar matters.
 
+### `mp regime`
+
+Prints a broader 1-3 month market regime card:
+
+- regime label / mood
+- explicit 1-3 month basis
+- cross-asset map
+- regime drivers
+- regime tensions
+- checks for the next session/week
+- next better regime question
+
+`mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup is a later phase, likely through `mp review --date YYYY-MM-DD` or a search-style review UX.
+
 ### `mp think "..."`
 
 Records your market interpretation and returns structured feedback:
@@ -157,6 +172,7 @@ aliases inside Codex/OMX sessions without changing the standalone shell CLI:
 
 ```text
 $mp-now
+$mp-regime
 $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
@@ -166,6 +182,7 @@ $mp-review
 These aliases are thin wrappers around the same local `mp` binary:
 
 - `$mp-now` -> `mp now`
+- `$mp-regime` -> `mp regime`
 - `$mp-ask` -> `mp ask`
 - `$mp-research` -> `mp research`
 - `$mp-think` -> `mp think`

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Prints a compact market pulse card:
 
 Live quotes are fetched through the Yahoo Finance chart endpoint by shelling out to `curl`. If a quote fails, the card still renders so the learning loop is not blocked.
 
+`mp now` is a session/daily pulse, not a weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `regularMarketPrice` versus `chartPreviousClose` from `range=5d&interval=1d` — usually the prior regular-session close for that asset. Because assets trade in different time zones, treat the card as a cross-asset snapshot and use `$mp-research` when the exact session calendar matters.
+
 ### `mp think "..."`
 
 Records your market interpretation and returns structured feedback:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Prints a broader 1-3 month market regime card:
 - checks for the next session/week
 - next better regime question
 
-`mp regime` is intentionally separate from `mp now`: `now` is a close-to-close pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
+`mp regime` is intentionally separate from `mp now`: `now` is a close-to-close pulse, while `regime` is the larger backdrop traders compare against short-term moves. Regime market change uses Yahoo `range=3mo&interval=1wk` weekly closes: latest weekly close value versus the first available weekly close, with `regularMarketPrice` as fallback only. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
 
 ### `mp week`
 
@@ -166,7 +166,7 @@ Prints a hybrid weekly market-and-learning card:
 - recurring journal themes and thesis habits
 - next-week check questions
 
-`mp week` fills the gap between `mp now` and `mp regime`: it is not a separate daily command and not a 1-3 month regime read. The default window is current-date based: the journal review uses the current local calendar week, while the market change uses Yahoo `range=1mo&interval=1d` to find the first close matching the current local week before comparing it with the latest `regularMarketPrice`. If an asset has not traded during the current local week yet, the weekly card falls back to the latest available close instead of pretending a week-to-date move exists.
+`mp week` fills the gap between `mp now` and `mp regime`: it is not a separate daily command and not a 1-3 month regime read. The default window is current-date based: the journal review uses the current local calendar week, while the market change uses Yahoo `range=1mo&interval=1d` to find the first close matching the current local week before comparing it with the latest daily close value. `regularMarketPrice` is fallback only. If an asset has not traded during the current local week yet, the weekly card falls back to the latest available close instead of pretending a week-to-date move exists.
 
 ### `mp calendar`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mp regime
 mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
 mp review
 mp review --date 2026-04-21
-mp review --ago 1
+mp review --days 1
 ```
 
 ## North star
@@ -148,7 +148,7 @@ Prints a broader 1-3 month market regime card:
 - checks for the next session/week
 - next better regime question
 
-`mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup is a later phase, likely through `mp review --date YYYY-MM-DD` or a search-style review UX.
+`mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD` and the easier `mp review --days N`; broader search-style review remains a later phase.
 
 ### `mp think "..."`
 
@@ -166,14 +166,14 @@ Records your market interpretation and returns structured feedback:
 
 Reviews recent pulses, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
 
-Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date, or `--ago N` for the common “N days ago” flow:
+Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date, or `--days N` for the common “N days back” flow:
 
 ```bash
 mp review --date 2026-04-21
-mp review --ago 1
+mp review --days 1
 ```
 
-`--limit N` can be combined with `--date`; the limit is applied after date matching, keeping the most recent matching entries. The date filter is explicit by design. Natural language lookup such as `어제` or `지난주` remains a later search/review phase.
+`--limit N` can be combined with `--date` or `--days`; the limit is applied after date matching, keeping the most recent matching entries. `--ago N` and `--days-ago N` remain accepted as compatibility aliases, but `--days N` is the preferred spelling. The date filter is explicit by design. Natural language lookup such as `어제` or `지난주` remains a later search/review phase.
 
 
 ## OMX/Codex aliases
@@ -189,7 +189,7 @@ $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
 $mp-review --date 2026-04-21
-$mp-review --ago 1
+$mp-review --days 1
 ```
 
 These aliases are thin wrappers around the same local `mp` binary:
@@ -199,7 +199,7 @@ These aliases are thin wrappers around the same local `mp` binary:
 - `$mp-ask` -> `mp ask`
 - `$mp-research` -> `mp research`
 - `$mp-think` -> `mp think`
-- `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --ago N`
+- `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --days N`
 
 The canonical `$mp ...` skill remains available for flexible calls. The aliases
 are explicit only: they do not auto-capture arbitrary market/economy sentences,

--- a/README.md
+++ b/README.md
@@ -147,6 +147,33 @@ Records your market interpretation and returns structured feedback:
 
 Reviews recent pulses, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
 
+
+## OMX/Codex aliases
+
+When the Codex/OMX skill adapter is installed, you can use readable `$mp-*`
+aliases inside Codex/OMX sessions without changing the standalone shell CLI:
+
+```text
+$mp-now
+$mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
+$mp-research "금리 하락이 성장주에 좋은 신호임?"
+$mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
+$mp-review
+```
+
+These aliases are thin wrappers around the same local `mp` binary:
+
+- `$mp-now` -> `mp now`
+- `$mp-ask` -> `mp ask`
+- `$mp-research` -> `mp research`
+- `$mp-think` -> `mp think`
+- `$mp-review` -> `mp review`
+
+The canonical `$mp ...` skill remains available for flexible calls. The aliases
+are explicit only: they do not auto-capture arbitrary market/economy sentences,
+and live/source-backed lookup still requires `$mp-research` or an existing
+`mp ... --research` flow.
+
 ## Storage
 
 By default, entries are written to:
@@ -193,6 +220,7 @@ make smoke
 The repo includes thin adapters that call the same standalone `mp` binary:
 
 - Codex skill: `adapters/codex-skill/SKILL.md`
+- Codex readable alias skills: `adapters/codex-skill/aliases/`
 - Claude Code slash command: `adapters/claude-command/mp/COMMAND.md`
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Prints a compact market pulse card:
 
 Live quotes are fetched through the Yahoo Finance chart endpoint by shelling out to `curl`. If a quote fails, the card still renders so the learning loop is not blocked.
 
-`mp now` is a session/daily pulse, not a weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `regularMarketPrice` versus `chartPreviousClose` from `range=5d&interval=1d` — usually the prior regular-session close for that asset. Because assets trade in different time zones, treat the card as a cross-asset snapshot and use `$mp-research` when the exact session calendar matters.
+`mp now` is a quote-session pulse, not an exact 24-hour, local calendar-day, or weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `regularMarketPrice` versus `chartPreviousClose` from `range=5d&interval=1d`, falling back to the prior daily close when needed. Because US indices, Korea, FX, futures, and crypto use different clocks, treat the card as a cross-asset directional snapshot and use `$mp-research` when the exact exchange calendar matters.
 
 ### `mp regime`
 
@@ -152,7 +152,7 @@ Prints a broader 1-3 month market regime card:
 - checks for the next session/week
 - next better regime question
 
-`mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
+`mp regime` is intentionally separate from `mp now`: `now` is a quote-session pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
 
 ### `mp week`
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Prints a compact market pulse card:
 
 Live quotes are fetched through the Yahoo Finance chart endpoint by shelling out to `curl`. If a quote fails, the card still renders so the learning loop is not blocked.
 
-`mp now` is a quote-session pulse, not an exact 24-hour, local calendar-day, or weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `regularMarketPrice` versus `chartPreviousClose` from `range=5d&interval=1d`, falling back to the prior daily close when needed. Because US indices, Korea, FX, futures, and crypto use different clocks, treat the card as a cross-asset directional snapshot and use `$mp-research` when the exact exchange calendar matters.
+`mp now` is a close-to-close pulse, not a high/low gap, exact 24-hour, local calendar-day, or weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `range=5d&interval=1d` daily closes: latest daily close value versus prior daily close. `regularMarketPrice` is fallback only when the close series is unavailable. Because US indices, Korea, FX, futures, and crypto use different clocks, treat the card as a cross-asset directional snapshot and use `$mp-research` when the exact exchange calendar matters.
 
 ### `mp regime`
 
@@ -152,7 +152,7 @@ Prints a broader 1-3 month market regime card:
 - checks for the next session/week
 - next better regime question
 
-`mp regime` is intentionally separate from `mp now`: `now` is a quote-session pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
+`mp regime` is intentionally separate from `mp now`: `now` is a close-to-close pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
 
 ### `mp week`
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ mp "대형 IPO 때문에 성장주가 강한 걸까?" --research
 mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 mp now
 mp week
+mp calendar
 mp regime
 mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
 mp review
 mp review --date 2026-04-21
 mp review --days 1
+mp review --this-week
 ```
 
 ## North star
@@ -149,7 +151,7 @@ Prints a broader 1-3 month market regime card:
 - checks for the next session/week
 - next better regime question
 
-`mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD` and the easier `mp review --days N`; broader search-style review remains a later phase.
+`mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD`, the easier `mp review --days N`, and calendar aliases like `mp review --this-week`; broader search-style review remains a later phase.
 
 ### `mp week`
 
@@ -164,6 +166,25 @@ Prints a hybrid weekly market-and-learning card:
 - next-week check questions
 
 `mp week` fills the gap between `mp now` and `mp regime`: it is not a separate daily command and not a 1-3 month regime read. The default window is current-date based: the journal review uses the current local calendar week, while the market change uses Yahoo `range=1mo&interval=1d` to find the first close matching the current local week before comparing it with the latest `regularMarketPrice`. If an asset has not traded during the current local week yet, the weekly card falls back to the latest available close instead of pretending a week-to-date move exists.
+
+### `mp calendar`
+
+Prints the local-date windows market-pulse uses for review shortcuts:
+
+- today
+- yesterday
+- this-week
+- last-week
+- matching `mp review` shortcut commands
+- explicit boundary that these are local-date helpers, not exchange-holiday calendars or trading signals
+
+Use it when you forget which date window a shortcut means:
+
+```bash
+mp calendar
+mp review --this-week
+mp review --last-week
+```
 
 ### `mp think "..."`
 
@@ -181,14 +202,18 @@ Records your market interpretation and returns structured feedback:
 
 Reviews recent pulses, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
 
-Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date, or `--days N` for the common “N days back” flow:
+Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date, `--days N` for the common “N days back” flow, or small readable aliases for common calendar windows:
 
 ```bash
 mp review --date 2026-04-21
 mp review --days 1
+mp review --today
+mp review --yesterday
+mp review --this-week
+mp review --last-week
 ```
 
-`--limit N` can be combined with `--date` or `--days`; the limit is applied after date matching, keeping the most recent matching entries. `--ago N` and `--days-ago N` remain accepted as compatibility aliases, but `--days N` is the preferred spelling. The date filter is explicit by design. Natural language lookup such as `어제` or `지난주` remains a later search/review phase.
+`--limit N` can be combined with one date/window selector; the limit is applied after matching, keeping the most recent matching entries. `--ago N` and `--days-ago N` remain accepted as compatibility aliases, but `--days N` is the preferred relative-day spelling. Use `mp calendar` when you want to inspect what `today`, `yesterday`, `this-week`, and `last-week` mean on the current local machine clock. The date filter is explicit by design. Broader natural-language lookup such as arbitrary `어제` / `지난주` phrasing remains a later search/review phase.
 
 
 ## OMX/Codex aliases
@@ -199,6 +224,7 @@ aliases inside Codex/OMX sessions without changing the standalone shell CLI:
 ```text
 $mp-now
 $mp-week
+$mp-calendar
 $mp-regime
 $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
@@ -206,17 +232,19 @@ $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
 $mp-review --date 2026-04-21
 $mp-review --days 1
+$mp-review --this-week
 ```
 
 These aliases are thin wrappers around the same local `mp` binary:
 
 - `$mp-now` -> `mp now`
 - `$mp-week` -> `mp week`
+- `$mp-calendar` -> `mp calendar`
 - `$mp-regime` -> `mp regime`
 - `$mp-ask` -> `mp ask`
 - `$mp-research` -> `mp research`
 - `$mp-think` -> `mp think`
-- `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --days N`
+- `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, `mp review --days N`, or a small period alias such as `mp review --this-week`
 
 The canonical `$mp ...` skill remains available for flexible calls. The aliases
 are explicit only: they do not auto-capture arbitrary market/economy sentences,

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ mp regime
 mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
 mp review
 mp review --date 2026-04-21
+mp review --ago 1
 ```
 
 ## North star
@@ -165,10 +166,11 @@ Records your market interpretation and returns structured feedback:
 
 Reviews recent pulses, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
 
-Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date:
+Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date, or `--ago N` for the common “N days ago” flow:
 
 ```bash
 mp review --date 2026-04-21
+mp review --ago 1
 ```
 
 `--limit N` can be combined with `--date`; the limit is applied after date matching, keeping the most recent matching entries. The date filter is explicit by design. Natural language lookup such as `어제` or `지난주` remains a later search/review phase.
@@ -187,6 +189,7 @@ $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
 $mp-review --date 2026-04-21
+$mp-review --ago 1
 ```
 
 These aliases are thin wrappers around the same local `mp` binary:
@@ -196,7 +199,7 @@ These aliases are thin wrappers around the same local `mp` binary:
 - `$mp-ask` -> `mp ask`
 - `$mp-research` -> `mp research`
 - `$mp-think` -> `mp think`
-- `$mp-review` -> `mp review` or `mp review --date YYYY-MM-DD`
+- `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --ago N`
 
 The canonical `$mp ...` skill remains available for flexible calls. The aliases
 are explicit only: they do not auto-capture arbitrary market/economy sentences,

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Prints a broader 1-3 month market regime card:
 
 Prints a hybrid weekly market-and-learning card:
 
-- rolling weekly market story
+- current-week market story
 - explicit market and journal basis
 - 1W cross-asset map
 - weekly market themes and tensions
@@ -163,7 +163,7 @@ Prints a hybrid weekly market-and-learning card:
 - recurring journal themes and thesis habits
 - next-week check questions
 
-`mp week` fills the gap between `mp now` and `mp regime`: it is not a separate daily command and not a 1-3 month regime read. The market window uses Yahoo `range=5d&interval=1d` versus the first available close, while the journal window scans the last 7 local dates before saving the weekly card.
+`mp week` fills the gap between `mp now` and `mp regime`: it is not a separate daily command and not a 1-3 month regime read. The default window is current-date based: the journal review uses the current local calendar week, while the market change uses Yahoo `range=1mo&interval=1d` to find the first close matching the current local week before comparing it with the latest `regularMarketPrice`. If an asset has not traded during the current local week yet, the weekly card falls back to the latest available close instead of pretending a week-to-date move exists.
 
 ### `mp think "..."`
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ mp now
 mp regime
 mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
 mp review
+mp review --date 2026-04-21
 ```
 
 ## North star
@@ -162,7 +163,15 @@ Records your market interpretation and returns structured feedback:
 
 ### `mp review`
 
-Reviews recent pulses, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
+Reviews recent pulses, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
+
+Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date:
+
+```bash
+mp review --date 2026-04-21
+```
+
+`--limit N` can be combined with `--date`; the limit is applied after date matching, keeping the most recent matching entries. The date filter is explicit by design. Natural language lookup such as `어제` or `지난주` remains a later search/review phase.
 
 
 ## OMX/Codex aliases
@@ -177,6 +186,7 @@ $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
+$mp-review --date 2026-04-21
 ```
 
 These aliases are thin wrappers around the same local `mp` binary:
@@ -186,7 +196,7 @@ These aliases are thin wrappers around the same local `mp` binary:
 - `$mp-ask` -> `mp ask`
 - `$mp-research` -> `mp research`
 - `$mp-think` -> `mp think`
-- `$mp-review` -> `mp review`
+- `$mp-review` -> `mp review` or `mp review --date YYYY-MM-DD`
 
 The canonical `$mp ...` skill remains available for flexible calls. The aliases
 are explicit only: they do not auto-capture arbitrary market/economy sentences,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ mp research "금리 하락이 성장주에 좋은 신호임?"
 mp "대형 IPO 때문에 성장주가 강한 걸까?" --research
 mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 mp now
+mp week
 mp regime
 mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
 mp review
@@ -150,6 +151,20 @@ Prints a broader 1-3 month market regime card:
 
 `mp regime` is intentionally separate from `mp now`: `now` is a session/daily pulse, while `regime` is the larger backdrop traders compare against short-term moves. Date-based journal lookup now lives in `mp review --date YYYY-MM-DD` and the easier `mp review --days N`; broader search-style review remains a later phase.
 
+### `mp week`
+
+Prints a hybrid weekly market-and-learning card:
+
+- rolling weekly market story
+- explicit market and journal basis
+- 1W cross-asset map
+- weekly market themes and tensions
+- this week's saved pulse/regime/inquiry/thought counts
+- recurring journal themes and thesis habits
+- next-week check questions
+
+`mp week` fills the gap between `mp now` and `mp regime`: it is not a separate daily command and not a 1-3 month regime read. The market window uses Yahoo `range=5d&interval=1d` versus the first available close, while the journal window scans the last 7 local dates before saving the weekly card.
+
 ### `mp think "..."`
 
 Records your market interpretation and returns structured feedback:
@@ -183,6 +198,7 @@ aliases inside Codex/OMX sessions without changing the standalone shell CLI:
 
 ```text
 $mp-now
+$mp-week
 $mp-regime
 $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
@@ -195,6 +211,7 @@ $mp-review --days 1
 These aliases are thin wrappers around the same local `mp` binary:
 
 - `$mp-now` -> `mp now`
+- `$mp-week` -> `mp week`
 - `$mp-regime` -> `mp regime`
 - `$mp-ask` -> `mp ask`
 - `$mp-research` -> `mp research`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ mp review
 mp review --date 2026-04-21
 mp review --days 1
 mp review --this-week
+mp find "금리" --this-week
 ```
 
 ## North star
@@ -198,6 +199,28 @@ Records your market interpretation and returns structured feedback:
 - next observation question
 - related concepts
 
+### `mp find "query"`
+
+Searches your local market-pulse journal and renders a recall card, not just raw grep output:
+
+- explicit query and date/window basis
+- matching entries with timestamp/type snippets
+- matched event counts
+- recurring themes in matches
+- next recall question
+- local-journal-only boundary
+
+Examples:
+
+```bash
+mp find "금리"
+mp find "달러" --this-week
+mp find "유가" --last-week
+mp find "반도체" --days 3 --limit 5
+```
+
+`mp search` is accepted as a thin alias for `mp find`. The first pass is intentionally explicit: it does not parse arbitrary natural-language dates, does not use exchange calendars, does not call live web providers, and does not add semantic/vector search.
+
 ### `mp review`
 
 Reviews recent pulses, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
@@ -233,6 +256,7 @@ $mp-review
 $mp-review --date 2026-04-21
 $mp-review --days 1
 $mp-review --this-week
+$mp-find "금리" --this-week
 ```
 
 These aliases are thin wrappers around the same local `mp` binary:
@@ -245,6 +269,7 @@ These aliases are thin wrappers around the same local `mp` binary:
 - `$mp-research` -> `mp research`
 - `$mp-think` -> `mp think`
 - `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, `mp review --days N`, or a small period alias such as `mp review --this-week`
+- `$mp-find` -> `mp find`, optionally with the same small date/window selectors
 
 The canonical `$mp ...` skill remains available for flexible calls. The aliases
 are explicit only: they do not auto-capture arbitrary market/economy sentences,

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -33,6 +33,7 @@ Then in Claude Code:
 /mp review --date 2026-04-21
 /mp review --days 1
 /mp review --this-week
+/mp find 금리 --this-week
 ```
 
 ## Contract

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -25,6 +25,7 @@ Then in Claude Code:
 /mp ask 대형 IPO 때문에 성장주가 강한 걸까?
 /mp research 금리 하락이 성장주에 좋은 신호임?
 /mp now
+/mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 ```

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -28,6 +28,7 @@ Then in Claude Code:
 /mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
+/mp review --date 2026-04-21
 ```
 
 ## Contract

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -25,6 +25,7 @@ Then in Claude Code:
 /mp ask 대형 IPO 때문에 성장주가 강한 걸까?
 /mp research 금리 하락이 성장주에 좋은 신호임?
 /mp now
+/mp week
 /mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -29,6 +29,7 @@ Then in Claude Code:
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 /mp review --date 2026-04-21
+/mp review --ago 1
 ```
 
 ## Contract

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -26,11 +26,13 @@ Then in Claude Code:
 /mp research 금리 하락이 성장주에 좋은 신호임?
 /mp now
 /mp week
+/mp calendar
 /mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 /mp review --date 2026-04-21
 /mp review --days 1
+/mp review --this-week
 ```
 
 ## Contract

--- a/adapters/claude-command/README.md
+++ b/adapters/claude-command/README.md
@@ -29,7 +29,7 @@ Then in Claude Code:
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 /mp review --date 2026-04-21
-/mp review --ago 1
+/mp review --days 1
 ```
 
 ## Contract

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -17,6 +17,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
+mp review --date 2026-04-21
 ```
 
 인자가 없으면 `/mp now`로 처리합니다.
@@ -31,6 +32,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
    - 알려진 명령어가 아닌 일반 텍스트: `mp "<question>"` 실행
    - `think <text>`: `mp think "<text>"` 실행
    - `review`: `mp review` 실행
+   - `review --date YYYY-MM-DD`: `mp review --date YYYY-MM-DD` 실행
 2. 가능한 한 로컬 CLI를 직접 실행합니다.
 3. CLI 출력은 핵심만 정리하되, 중요한 피드백 구조는 유지합니다.
 4. `MARKET_PULSE_SEARCH_CMD`가 설정되어 있으면 `mp`가 제한형 JSONL source bridge로 사용하게 두고, slash command 프롬프트에서 검색을 재구현하지 않습니다.
@@ -92,4 +94,5 @@ mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 
 ```bash
 mp review
+mp review --date 2026-04-21
 ```

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -1,6 +1,6 @@
 ---
 name: mp
-description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp regime, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
+description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 주간 학습 카드, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp week, /mp regime, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
 ---
 
 # market-pulse Claude Command
@@ -14,6 +14,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp ask 대형 IPO 때문에 성장주가 강한 걸까?
 /mp research 금리 하락이 성장주에 좋은 신호임?
 /mp now
+/mp week
 /mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
@@ -27,6 +28,7 @@ mp review --days 1
 
 1. 사용자의 인자를 파악합니다.
    - 없음 또는 `now`: `mp now` 실행
+   - `week`: `mp week` 실행
    - `regime`: `mp regime` 실행
    - `ask <question>`: `mp ask "<question>"` 실행
    - `research <question>`: `mp research "<question>"` 실행
@@ -78,6 +80,12 @@ mp research "금리 하락이 성장주에 좋은 신호임?"
 
 ```bash
 mp now
+```
+
+### `/mp week`
+
+```bash
+mp week
 ```
 
 ### `/mp regime`

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -1,6 +1,6 @@
 ---
 name: mp
-description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 주간 학습 카드, 날짜 창 확인, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp week, /mp calendar, /mp regime, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
+description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 주간 학습 카드, 날짜 창 확인, 로컬 저널 recall 검색, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp week, /mp calendar, /mp regime, /mp think, /mp review, /mp find 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
 ---
 
 # market-pulse Claude Command
@@ -22,6 +22,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp review --date 2026-04-21
 /mp review --days 1
 /mp review --this-week
+/mp find 금리 --this-week
 ```
 
 인자가 없으면 `/mp now`로 처리합니다.
@@ -41,6 +42,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
    - `review --date YYYY-MM-DD`: `mp review --date YYYY-MM-DD` 실행
    - `review --days N`: `mp review --days N` 실행
    - `review --today|--yesterday|--this-week|--last-week`: 같은 selector로 `mp review` 실행
+   - `find <query>` 또는 `search <query>`: `mp find "<query>"` 실행, selector가 있으면 보존
 2. 가능한 한 로컬 CLI를 직접 실행합니다.
 3. CLI 출력은 핵심만 정리하되, 중요한 피드백 구조는 유지합니다.
 4. `MARKET_PULSE_SEARCH_CMD`가 설정되어 있으면 `mp`가 제한형 JSONL source bridge로 사용하게 두고, slash command 프롬프트에서 검색을 재구현하지 않습니다.
@@ -117,4 +119,10 @@ mp review
 mp review --date 2026-04-21
 mp review --days 1
 mp review --this-week
+```
+
+### `/mp find ...query...`
+
+```bash
+mp find "금리" --this-week
 ```

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -1,6 +1,6 @@
 ---
 name: mp
-description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
+description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp regime, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
 ---
 
 # market-pulse Claude Command
@@ -14,6 +14,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp ask 대형 IPO 때문에 성장주가 강한 걸까?
 /mp research 금리 하락이 성장주에 좋은 신호임?
 /mp now
+/mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 ```
@@ -24,6 +25,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 
 1. 사용자의 인자를 파악합니다.
    - 없음 또는 `now`: `mp now` 실행
+   - `regime`: `mp regime` 실행
    - `ask <question>`: `mp ask "<question>"` 실행
    - `research <question>`: `mp research "<question>"` 실행
    - 알려진 명령어가 아닌 일반 텍스트: `mp "<question>"` 실행
@@ -72,6 +74,12 @@ mp research "금리 하락이 성장주에 좋은 신호임?"
 
 ```bash
 mp now
+```
+
+### `/mp regime`
+
+```bash
+mp regime
 ```
 
 ### `/mp think ...`

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -18,7 +18,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 mp review --date 2026-04-21
-mp review --ago 1
+mp review --days 1
 ```
 
 인자가 없으면 `/mp now`로 처리합니다.
@@ -34,7 +34,7 @@ mp review --ago 1
    - `think <text>`: `mp think "<text>"` 실행
    - `review`: `mp review` 실행
    - `review --date YYYY-MM-DD`: `mp review --date YYYY-MM-DD` 실행
-   - `review --ago N`: `mp review --ago N` 실행
+   - `review --days N`: `mp review --days N` 실행
 2. 가능한 한 로컬 CLI를 직접 실행합니다.
 3. CLI 출력은 핵심만 정리하되, 중요한 피드백 구조는 유지합니다.
 4. `MARKET_PULSE_SEARCH_CMD`가 설정되어 있으면 `mp`가 제한형 JSONL source bridge로 사용하게 두고, slash command 프롬프트에서 검색을 재구현하지 않습니다.
@@ -97,5 +97,5 @@ mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 ```bash
 mp review
 mp review --date 2026-04-21
-mp review --ago 1
+mp review --days 1
 ```

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -18,6 +18,7 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
 mp review --date 2026-04-21
+mp review --ago 1
 ```
 
 인자가 없으면 `/mp now`로 처리합니다.
@@ -33,6 +34,7 @@ mp review --date 2026-04-21
    - `think <text>`: `mp think "<text>"` 실행
    - `review`: `mp review` 실행
    - `review --date YYYY-MM-DD`: `mp review --date YYYY-MM-DD` 실행
+   - `review --ago N`: `mp review --ago N` 실행
 2. 가능한 한 로컬 CLI를 직접 실행합니다.
 3. CLI 출력은 핵심만 정리하되, 중요한 피드백 구조는 유지합니다.
 4. `MARKET_PULSE_SEARCH_CMD`가 설정되어 있으면 `mp`가 제한형 JSONL source bridge로 사용하게 두고, slash command 프롬프트에서 검색을 재구현하지 않습니다.
@@ -95,4 +97,5 @@ mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 ```bash
 mp review
 mp review --date 2026-04-21
+mp review --ago 1
 ```

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -1,6 +1,6 @@
 ---
 name: mp
-description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 주간 학습 카드, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp week, /mp regime, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
+description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 주간 학습 카드, 날짜 창 확인, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp week, /mp calendar, /mp regime, /mp think, /mp review 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
 ---
 
 # market-pulse Claude Command
@@ -15,11 +15,13 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp research 금리 하락이 성장주에 좋은 신호임?
 /mp now
 /mp week
+/mp calendar
 /mp regime
 /mp think 금리가 부담인데도 반도체가 버티는 것 같다
 /mp review
-mp review --date 2026-04-21
-mp review --days 1
+/mp review --date 2026-04-21
+/mp review --days 1
+/mp review --this-week
 ```
 
 인자가 없으면 `/mp now`로 처리합니다.
@@ -29,6 +31,7 @@ mp review --days 1
 1. 사용자의 인자를 파악합니다.
    - 없음 또는 `now`: `mp now` 실행
    - `week`: `mp week` 실행
+   - `calendar` 또는 `cal`: `mp calendar` 실행
    - `regime`: `mp regime` 실행
    - `ask <question>`: `mp ask "<question>"` 실행
    - `research <question>`: `mp research "<question>"` 실행
@@ -37,6 +40,7 @@ mp review --days 1
    - `review`: `mp review` 실행
    - `review --date YYYY-MM-DD`: `mp review --date YYYY-MM-DD` 실행
    - `review --days N`: `mp review --days N` 실행
+   - `review --today|--yesterday|--this-week|--last-week`: 같은 selector로 `mp review` 실행
 2. 가능한 한 로컬 CLI를 직접 실행합니다.
 3. CLI 출력은 핵심만 정리하되, 중요한 피드백 구조는 유지합니다.
 4. `MARKET_PULSE_SEARCH_CMD`가 설정되어 있으면 `mp`가 제한형 JSONL source bridge로 사용하게 두고, slash command 프롬프트에서 검색을 재구현하지 않습니다.
@@ -88,6 +92,12 @@ mp now
 mp week
 ```
 
+### `/mp calendar`
+
+```bash
+mp calendar
+```
+
 ### `/mp regime`
 
 ```bash
@@ -106,4 +116,5 @@ mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 mp review
 mp review --date 2026-04-21
 mp review --days 1
+mp review --this-week
 ```

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -22,7 +22,7 @@ cp adapters/codex-skill/SKILL.md ~/.codex/skills/mp/SKILL.md
 Install the readable alias skills:
 
 ```bash
-for name in mp-now mp-week mp-calendar mp-regime mp-ask mp-research mp-think mp-review; do
+for name in mp-now mp-week mp-calendar mp-regime mp-ask mp-research mp-think mp-review mp-find; do
   mkdir -p "$HOME/.codex/skills/$name"
   cp "adapters/codex-skill/aliases/$name/SKILL.md" "$HOME/.codex/skills/$name/SKILL.md"
 done
@@ -46,6 +46,7 @@ $mp review
 $mp review --date 2026-04-21
 $mp review --days 1
 $mp review --this-week
+$mp find "금리" --this-week
 
 $mp-now
 $mp-week
@@ -58,6 +59,7 @@ $mp-review
 $mp-review --date 2026-04-21
 $mp-review --days 1
 $mp-review --this-week
+$mp-find "금리" --this-week
 ```
 
 ## Contract

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -22,7 +22,7 @@ cp adapters/codex-skill/SKILL.md ~/.codex/skills/mp/SKILL.md
 Install the readable alias skills:
 
 ```bash
-for name in mp-now mp-ask mp-research mp-think mp-review; do
+for name in mp-now mp-regime mp-ask mp-research mp-think mp-review; do
   mkdir -p "$HOME/.codex/skills/$name"
   cp "adapters/codex-skill/aliases/$name/SKILL.md" "$HOME/.codex/skills/$name/SKILL.md"
 done
@@ -36,12 +36,14 @@ names to appear in the session skill list.
 ```text
 $mp "금리가 내려간 게 진짜 완화 기대 때문임?"
 $mp now
+$mp regime
 $mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp research "금리 하락이 성장주에 좋은 신호임?"
 $mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp review
 
 $mp-now
+$mp-regime
 $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -41,6 +41,7 @@ $mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp research "금리 하락이 성장주에 좋은 신호임?"
 $mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp review
+$mp review --date 2026-04-21
 
 $mp-now
 $mp-regime
@@ -48,6 +49,7 @@ $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
+$mp-review --date 2026-04-21
 ```
 
 ## Contract

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -42,7 +42,7 @@ $mp research "금리 하락이 성장주에 좋은 신호임?"
 $mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp review
 $mp review --date 2026-04-21
-$mp review --ago 1
+$mp review --days 1
 
 $mp-now
 $mp-regime
@@ -51,7 +51,7 @@ $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
 $mp-review --date 2026-04-21
-$mp-review --ago 1
+$mp-review --days 1
 ```
 
 ## Contract

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -1,0 +1,55 @@
+# Codex skill adapter
+
+This adapter exposes `market-pulse` as thin Codex/OMX skills that call the local
+Rust `mp` CLI. The skill prompts should not reimplement market-pulse logic.
+
+## Install
+
+First install the Rust CLI:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```
+
+Install the canonical `$mp` skill:
+
+```bash
+mkdir -p ~/.codex/skills/mp
+cp adapters/codex-skill/SKILL.md ~/.codex/skills/mp/SKILL.md
+```
+
+Install the readable alias skills:
+
+```bash
+for name in mp-now mp-ask mp-research mp-think mp-review; do
+  mkdir -p "$HOME/.codex/skills/$name"
+  cp "adapters/codex-skill/aliases/$name/SKILL.md" "$HOME/.codex/skills/$name/SKILL.md"
+done
+```
+
+You may need to restart or reload the Codex/OMX session for newly installed skill
+names to appear in the session skill list.
+
+## Commands
+
+```text
+$mp "금리가 내려간 게 진짜 완화 기대 때문임?"
+$mp now
+$mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
+$mp research "금리 하락이 성장주에 좋은 신호임?"
+$mp think "금리가 부담인데도 반도체가 버티는 것 같다"
+$mp review
+
+$mp-now
+$mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
+$mp-research "금리 하락이 성장주에 좋은 신호임?"
+$mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
+$mp-review
+```
+
+## Contract
+
+- `$mp-*` aliases are explicit only; they do not auto-capture arbitrary market or economy text.
+- `$mp-research` preserves the existing `MARKET_PULSE_SEARCH_CMD` behavior and no-provider fallback.
+- All skills keep the market-literacy boundary: no buy/sell recommendations, price targets, stop-loss, portfolio instructions, sensational headlines, or false certainty.

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -42,6 +42,7 @@ $mp research "금리 하락이 성장주에 좋은 신호임?"
 $mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp review
 $mp review --date 2026-04-21
+$mp review --ago 1
 
 $mp-now
 $mp-regime
@@ -50,6 +51,7 @@ $mp-research "금리 하락이 성장주에 좋은 신호임?"
 $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
 $mp-review --date 2026-04-21
+$mp-review --ago 1
 ```
 
 ## Contract

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -22,7 +22,7 @@ cp adapters/codex-skill/SKILL.md ~/.codex/skills/mp/SKILL.md
 Install the readable alias skills:
 
 ```bash
-for name in mp-now mp-week mp-regime mp-ask mp-research mp-think mp-review; do
+for name in mp-now mp-week mp-calendar mp-regime mp-ask mp-research mp-think mp-review; do
   mkdir -p "$HOME/.codex/skills/$name"
   cp "adapters/codex-skill/aliases/$name/SKILL.md" "$HOME/.codex/skills/$name/SKILL.md"
 done
@@ -37,6 +37,7 @@ names to appear in the session skill list.
 $mp "금리가 내려간 게 진짜 완화 기대 때문임?"
 $mp now
 $mp week
+$mp calendar
 $mp regime
 $mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp research "금리 하락이 성장주에 좋은 신호임?"
@@ -44,9 +45,11 @@ $mp think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp review
 $mp review --date 2026-04-21
 $mp review --days 1
+$mp review --this-week
 
 $mp-now
 $mp-week
+$mp-calendar
 $mp-regime
 $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"
@@ -54,6 +57,7 @@ $mp-think "금리가 부담인데도 반도체가 버티는 것 같다"
 $mp-review
 $mp-review --date 2026-04-21
 $mp-review --days 1
+$mp-review --this-week
 ```
 
 ## Contract

--- a/adapters/codex-skill/README.md
+++ b/adapters/codex-skill/README.md
@@ -22,7 +22,7 @@ cp adapters/codex-skill/SKILL.md ~/.codex/skills/mp/SKILL.md
 Install the readable alias skills:
 
 ```bash
-for name in mp-now mp-regime mp-ask mp-research mp-think mp-review; do
+for name in mp-now mp-week mp-regime mp-ask mp-research mp-think mp-review; do
   mkdir -p "$HOME/.codex/skills/$name"
   cp "adapters/codex-skill/aliases/$name/SKILL.md" "$HOME/.codex/skills/$name/SKILL.md"
 done
@@ -36,6 +36,7 @@ names to appear in the session skill list.
 ```text
 $mp "금리가 내려간 게 진짜 완화 기대 때문임?"
 $mp now
+$mp week
 $mp regime
 $mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp research "금리 하락이 성장주에 좋은 신호임?"
@@ -45,6 +46,7 @@ $mp review --date 2026-04-21
 $mp review --days 1
 
 $mp-now
+$mp-week
 $mp-regime
 $mp-ask "대형 IPO 때문에 성장주가 강한 걸까?"
 $mp-research "금리 하락이 성장주에 좋은 신호임?"

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp
-description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, weekly learning, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp week, mp regime, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
-argument-hint: "[question]|ask [question]|research [question]|now|week|regime|think|review [text]"
+description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, weekly learning, calendar windows, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp week, mp calendar, mp regime, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
+argument-hint: "[question]|ask [question]|research [question]|now|week|calendar|regime|think|review [selector]"
 ---
 
 Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in the prompt.
@@ -14,21 +14,24 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp <question> --research` -> run `mp "<question>" --research`
 - `$mp now` -> run `mp now`
 - `$mp week` -> run `mp week`
+- `$mp calendar` -> run `mp calendar`
 - `$mp regime` -> run `mp regime`
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
 - `$mp review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
 - `$mp review --days N` -> run `mp review --days N`
+- `$mp review --today|--yesterday|--this-week|--last-week` -> run the same `mp review` selector
 
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
 - `$mp-now` -> run `mp now`
 - `$mp-week` -> run `mp week`
+- `$mp-calendar` -> run `mp calendar`
 - `$mp-regime` -> run `mp regime`
 - `$mp-ask <question>` -> run `mp ask "<question>"`
 - `$mp-research <question>` -> run `mp research "<question>"`
 - `$mp-think <text>` -> run `mp think "<text>"`
-- `$mp-review` -> run `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --days N` when a date selector is supplied
+- `$mp-review` -> run `mp review`, `mp review --date YYYY-MM-DD`, `mp review --days N`, or a small period selector such as `mp review --this-week` when supplied
 
 If the user invokes `$mp` without arguments, treat it as `$mp now`.
 

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -16,6 +16,14 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
 
+Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
+
+- `$mp-now` -> run `mp now`
+- `$mp-ask <question>` -> run `mp ask "<question>"`
+- `$mp-research <question>` -> run `mp research "<question>"`
+- `$mp-think <text>` -> run `mp think "<text>"`
+- `$mp-review` -> run `mp review`
+
 If the user invokes `$mp` without arguments, treat it as `$mp now`.
 
 ## Rules

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp
-description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp regime, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
-argument-hint: "[question]|ask [question]|research [question]|now|regime|think|review [text]"
+description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, weekly learning, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp week, mp regime, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
+argument-hint: "[question]|ask [question]|research [question]|now|week|regime|think|review [text]"
 ---
 
 Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in the prompt.
@@ -13,6 +13,7 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp research <question>` -> run `mp research "<question>"`
 - `$mp <question> --research` -> run `mp "<question>" --research`
 - `$mp now` -> run `mp now`
+- `$mp week` -> run `mp week`
 - `$mp regime` -> run `mp regime`
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
@@ -22,6 +23,7 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
 - `$mp-now` -> run `mp now`
+- `$mp-week` -> run `mp week`
 - `$mp-regime` -> run `mp regime`
 - `$mp-ask <question>` -> run `mp ask "<question>"`
 - `$mp-research <question>` -> run `mp research "<question>"`

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -17,6 +17,7 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
 - `$mp review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
+- `$mp review --ago N` -> run `mp review --ago N`
 
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
@@ -25,7 +26,7 @@ Readable alias skills are also available when installed from `adapters/codex-ski
 - `$mp-ask <question>` -> run `mp ask "<question>"`
 - `$mp-research <question>` -> run `mp research "<question>"`
 - `$mp-think <text>` -> run `mp think "<text>"`
-- `$mp-review` -> run `mp review` or `mp review --date YYYY-MM-DD` when a date flag is supplied
+- `$mp-review` -> run `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --ago N` when a date selector is supplied
 
 If the user invokes `$mp` without arguments, treat it as `$mp now`.
 

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -17,7 +17,7 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
 - `$mp review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
-- `$mp review --ago N` -> run `mp review --ago N`
+- `$mp review --days N` -> run `mp review --days N`
 
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
@@ -26,7 +26,7 @@ Readable alias skills are also available when installed from `adapters/codex-ski
 - `$mp-ask <question>` -> run `mp ask "<question>"`
 - `$mp-research <question>` -> run `mp research "<question>"`
 - `$mp-think <text>` -> run `mp think "<text>"`
-- `$mp-review` -> run `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --ago N` when a date selector is supplied
+- `$mp-review` -> run `mp review`, `mp review --date YYYY-MM-DD`, or `mp review --days N` when a date selector is supplied
 
 If the user invokes `$mp` without arguments, treat it as `$mp now`.
 

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp
-description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, weekly learning, calendar windows, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp week, mp calendar, mp regime, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
-argument-hint: "[question]|ask [question]|research [question]|now|week|calendar|regime|think|review [selector]"
+description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, weekly learning, calendar windows, local journal recall, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp week, mp calendar, mp regime, mp think, mp review, mp find, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
+argument-hint: "[question]|ask [question]|research [question]|now|week|calendar|regime|think|review [selector]|find [query]"
 ---
 
 Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in the prompt.
@@ -21,6 +21,7 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
 - `$mp review --days N` -> run `mp review --days N`
 - `$mp review --today|--yesterday|--this-week|--last-week` -> run the same `mp review` selector
+- `$mp find <query> [selector]` -> run `mp find "<query>" [selector]`
 
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
@@ -32,6 +33,7 @@ Readable alias skills are also available when installed from `adapters/codex-ski
 - `$mp-research <question>` -> run `mp research "<question>"`
 - `$mp-think <text>` -> run `mp think "<text>"`
 - `$mp-review` -> run `mp review`, `mp review --date YYYY-MM-DD`, `mp review --days N`, or a small period selector such as `mp review --this-week` when supplied
+- `$mp-find <query>` -> run `mp find "<query>"` with optional date/window selectors
 
 If the user invokes `$mp` without arguments, treat it as `$mp now`.
 

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -16,6 +16,7 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp regime` -> run `mp regime`
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
+- `$mp review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
 
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
@@ -24,7 +25,7 @@ Readable alias skills are also available when installed from `adapters/codex-ski
 - `$mp-ask <question>` -> run `mp ask "<question>"`
 - `$mp-research <question>` -> run `mp research "<question>"`
 - `$mp-think <text>` -> run `mp think "<text>"`
-- `$mp-review` -> run `mp review`
+- `$mp-review` -> run `mp review` or `mp review --date YYYY-MM-DD` when a date flag is supplied
 
 If the user invokes `$mp` without arguments, treat it as `$mp now`.
 

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp
-description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
-argument-hint: "[question]|ask [question]|research [question]|now|think|review [text]"
+description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp regime, mp think, mp review, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
+argument-hint: "[question]|ask [question]|research [question]|now|regime|think|review [text]"
 ---
 
 Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in the prompt.
@@ -13,12 +13,14 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 - `$mp research <question>` -> run `mp research "<question>"`
 - `$mp <question> --research` -> run `mp "<question>" --research`
 - `$mp now` -> run `mp now`
+- `$mp regime` -> run `mp regime`
 - `$mp think <text>` -> run `mp think "<text>"`
 - `$mp review` -> run `mp review`
 
 Readable alias skills are also available when installed from `adapters/codex-skill/aliases/`:
 
 - `$mp-now` -> run `mp now`
+- `$mp-regime` -> run `mp regime`
 - `$mp-ask <question>` -> run `mp ask "<question>"`
 - `$mp-research <question>` -> run `mp research "<question>"`
 - `$mp-think <text>` -> run `mp think "<text>"`

--- a/adapters/codex-skill/aliases/mp-ask/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-ask/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mp-ask
+description: "Run market-pulse ask mode for terminal-native market question scaffolding. Use when the user says $mp-ask <question>."
+argument-hint: "<question>"
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-ask <question>` -> run `mp ask "<question>"`
+
+If the user invokes `$mp-ask` without a question, show a short usage hint and ask for the missing market question; do not invent one.
+
+## Example CLI call
+
+```bash
+mp ask "금리가 내려간 게 진짜 완화 기대 때문임?"
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-calendar/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-calendar/SKILL.md
@@ -1,27 +1,21 @@
 ---
-name: mp-review
-description: "Run market-pulse review mode for recent or date-windowed market inquiry/thought review. Use when the user says $mp-review."
-argument-hint: "[--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]"
+name: mp-calendar
+description: "Run market-pulse calendar mode for local date windows and review shortcuts. Use when the user says $mp-calendar or wants to inspect today/yesterday/this-week/last-week review windows."
+argument-hint: ""
 ---
 
 Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
 
 ## Command
 
-- `$mp-review` -> run `mp review`
-- `$mp-review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
-- `$mp-review --days N` -> run `mp review --days N`
-- `$mp-review --today|--yesterday|--this-week|--last-week` -> run the same `mp review` selector
+- `$mp-calendar` -> run `mp calendar`
 
-This alias takes no required argument. It reviews recent saved market-pulse entries, or a specific journal date when `--date YYYY-MM-DD`, `--days N`, `--ago N`, `--days-ago N`, `--today`, `--yesterday`, `--this-week`, or `--last-week` is supplied. Prefer `--days N` for relative-day examples and `--this-week` for weekly review examples.
+This alias takes no required argument. It prints local-date windows and the matching `mp review` shortcut commands. If extra market text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
 
 ## Example CLI call
 
 ```bash
-mp review
-mp review --date 2026-04-21
-mp review --days 1
-mp review --this-week
+mp calendar
 ```
 
 ## Safety / Product Boundary
@@ -40,6 +34,7 @@ SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/m
 - Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
 - Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
 - Do not add trading advice or portfolio guidance.
+- Do not treat local date windows as exchange-holiday calendars, trading signals, or market session proof.
 
 ## Fallback
 

--- a/adapters/codex-skill/aliases/mp-find/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-find/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: mp-find
+description: "Run market-pulse find mode for local journal recall search. Use when the user says $mp-find <query> or wants to find prior market-pulse notes."
+argument-hint: "<query> [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]"
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-find <query>` -> run `mp find "<query>"`
+- `$mp-find <query> --this-week` -> run `mp find "<query>" --this-week`
+- `$mp-find <query> --last-week` -> run `mp find "<query>" --last-week`
+
+If the user invokes `$mp-find` without a query, show a short usage hint and ask for the missing journal search keyword; do not invent one.
+
+## Example CLI call
+
+```bash
+mp find "금리" --this-week
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. `mp find` searches the local journal only.
+- Do not add trading advice or portfolio guidance.
+- Do not treat `--this-week` / `--last-week` as exchange-calendar semantics.
+- Do not turn the alias into fuzzy natural-language date parsing or semantic/vector search.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-now/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-now/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mp-now
+description: "Run market-pulse now mode for a compact terminal-native market pulse card. Use when the user says $mp-now or wants the current market pulse."
+argument-hint: ""
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-now` -> run `mp now`
+
+This alias takes no required argument. If extra text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
+
+## Example CLI call
+
+```bash
+mp now
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-regime/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-regime/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: mp-regime
+description: "Run market-pulse regime mode for 1-3 month market regime context. Use when the user says $mp-regime or asks for broader market regime/backdrop."
+argument-hint: ""
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-regime` -> run `mp regime`
+
+This alias takes no required argument. It prints a broader 1-3 month regime card, distinct from the session/daily `$mp-now` card. If extra text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
+
+## Example CLI call
+
+```bash
+mp regime
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+- Do not treat the regime card as a backtest, price forecast, or position instruction.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-research/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-research/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mp-research
+description: "Run market-pulse research mode for explicit source-aware market inquiry. Use when the user says $mp-research <question>."
+argument-hint: "<question>"
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-research <question>` -> run `mp research "<question>"`
+
+If the user invokes `$mp-research` without a question, show a short usage hint and ask for the missing market question; do not invent one.
+
+## Example CLI call
+
+```bash
+mp research "대형 IPO 때문에 성장주가 강한 걸까?"
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-review/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp-review
 description: "Run market-pulse review mode for recent market inquiry/thought review. Use when the user says $mp-review."
-argument-hint: "[--date YYYY-MM-DD]"
+argument-hint: "[--date YYYY-MM-DD|--ago N]"
 ---
 
 Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
@@ -10,14 +10,16 @@ Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in
 
 - `$mp-review` -> run `mp review`
 - `$mp-review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
+- `$mp-review --ago N` -> run `mp review --ago N`
 
-This alias takes no required argument. It reviews recent saved market-pulse entries, or a specific journal date when `--date YYYY-MM-DD` is supplied.
+This alias takes no required argument. It reviews recent saved market-pulse entries, or a specific journal date when `--date YYYY-MM-DD`, `--ago N`, or `--days-ago N` is supplied.
 
 ## Example CLI call
 
 ```bash
 mp review
 mp review --date 2026-04-21
+mp review --ago 1
 ```
 
 ## Safety / Product Boundary

--- a/adapters/codex-skill/aliases/mp-review/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp-review
 description: "Run market-pulse review mode for recent market inquiry/thought review. Use when the user says $mp-review."
-argument-hint: ""
+argument-hint: "[--date YYYY-MM-DD]"
 ---
 
 Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
@@ -9,13 +9,15 @@ Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in
 ## Command
 
 - `$mp-review` -> run `mp review`
+- `$mp-review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
 
-This alias takes no required argument. It reviews recent saved market-pulse entries.
+This alias takes no required argument. It reviews recent saved market-pulse entries, or a specific journal date when `--date YYYY-MM-DD` is supplied.
 
 ## Example CLI call
 
 ```bash
 mp review
+mp review --date 2026-04-21
 ```
 
 ## Safety / Product Boundary

--- a/adapters/codex-skill/aliases/mp-review/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp-review
 description: "Run market-pulse review mode for recent market inquiry/thought review. Use when the user says $mp-review."
-argument-hint: "[--date YYYY-MM-DD|--ago N]"
+argument-hint: "[--date YYYY-MM-DD|--days N]"
 ---
 
 Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
@@ -10,16 +10,16 @@ Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in
 
 - `$mp-review` -> run `mp review`
 - `$mp-review --date YYYY-MM-DD` -> run `mp review --date YYYY-MM-DD`
-- `$mp-review --ago N` -> run `mp review --ago N`
+- `$mp-review --days N` -> run `mp review --days N`
 
-This alias takes no required argument. It reviews recent saved market-pulse entries, or a specific journal date when `--date YYYY-MM-DD`, `--ago N`, or `--days-ago N` is supplied.
+This alias takes no required argument. It reviews recent saved market-pulse entries, or a specific journal date when `--date YYYY-MM-DD`, `--days N`, `--ago N`, or `--days-ago N` is supplied. Prefer `--days N` in examples and user-facing guidance.
 
 ## Example CLI call
 
 ```bash
 mp review
 mp review --date 2026-04-21
-mp review --ago 1
+mp review --days 1
 ```
 
 ## Safety / Product Boundary

--- a/adapters/codex-skill/aliases/mp-review/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mp-review
+description: "Run market-pulse review mode for recent market inquiry/thought review. Use when the user says $mp-review."
+argument-hint: ""
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-review` -> run `mp review`
+
+This alias takes no required argument. It reviews recent saved market-pulse entries.
+
+## Example CLI call
+
+```bash
+mp review
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-think/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-think/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mp-think
+description: "Run market-pulse think mode to record a user market interpretation and return structured feedback. Use when the user says $mp-think <text>."
+argument-hint: "<text>"
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-think <text>` -> run `mp think "<text>"`
+
+If the user invokes `$mp-think` without text, show a short usage hint and ask for the thought/interpretation; do not invent one.
+
+## Example CLI call
+
+```bash
+mp think "금리가 부담인데도 반도체가 버티는 걸 보면 성장 기대가 아직 남아있는 것 같다"
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/adapters/codex-skill/aliases/mp-week/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-week/SKILL.md
@@ -10,7 +10,7 @@ Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in
 
 - `$mp-week` -> run `mp week`
 
-This alias takes no required argument. It prints a weekly learning card that combines a rolling weekly market view, this week's saved market-pulse journal themes, and next-week check questions. If extra text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
+This alias takes no required argument. It prints a weekly learning card that combines a current-local-week market view, this week's saved market-pulse journal themes, and next-week check questions. If extra text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
 
 ## Example CLI call
 

--- a/adapters/codex-skill/aliases/mp-week/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-week/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: mp-week
+description: "Run market-pulse week mode for a hybrid weekly market-and-learning card. Use when the user says $mp-week or wants this week's market pulse plus their question/thought review."
+argument-hint: ""
+---
+
+Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in the prompt.
+
+## Command
+
+- `$mp-week` -> run `mp week`
+
+This alias takes no required argument. It prints a weekly learning card that combines a rolling weekly market view, this week's saved market-pulse journal themes, and next-week check questions. If extra text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
+
+## Example CLI call
+
+```bash
+mp week
+```
+
+## Safety / Product Boundary
+
+SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/mp/SKILL.md` `## Rules`.
+
+- Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
+- Frame output as market literacy and reasoning practice.
+- Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
+- If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Avoid: sensational headlines, numbers-only dashboards, false certainty.
+
+## Non-goals
+
+- Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
+- Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
+- Do not add trading advice or portfolio guidance.
+
+## Fallback
+
+If the `mp` executable is missing, install the Rust CLI locally:
+
+```bash
+cd ~/dev/market-pulse
+cargo install --path . --force
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,8 +38,8 @@ Adapters should call the standalone `mp` CLI instead of making the core depend o
 
 Planned or current adapters:
 
-- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp think ...`, `$mp review`
-- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp think ...`, `/mp review`
+- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp regime`, `$mp think ...`, `$mp review`
+- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp regime`, `/mp think ...`, `/mp review`
 - OMX hook: optional compact pulse at session start or long task completion
 - tmux popup/status: optional compact pulse
 - cron/launchd: optional scheduled snapshots

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ Initial code may keep these simple, but the boundaries should stay visible:
 - lens hooks: risk-on/off, rates vs growth, dollar liquidity, Korea market, AI/semis, IPO/event, positioning/flow
 - inquiry hooks: question breakdown, possible explanations, evidence checks, counter-view, next better question
 - research inquiry hooks: source metadata, source-backed claims, no-source fallback, data-to-check prompts
+- weekly hooks: rolling 1W market story, 7-local-day journal summary, next-week check questions
 - feedback hooks: claim extraction, thesis typing, evidence checks, counter-view, next question, concept linking
 - renderer hooks: terminal, compact, markdown, JSON
 - memory hooks: JSONL first, SQLite later if needed
@@ -38,8 +39,8 @@ Adapters should call the standalone `mp` CLI instead of making the core depend o
 
 Planned or current adapters:
 
-- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp regime`, `$mp think ...`, `$mp review`
-- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp regime`, `/mp think ...`, `/mp review`
+- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp week`, `$mp regime`, `$mp think ...`, `$mp review`
+- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp week`, `/mp regime`, `/mp think ...`, `/mp review`
 - OMX hook: optional compact pulse at session start or long task completion
 - tmux popup/status: optional compact pulse
 - cron/launchd: optional scheduled snapshots

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@ Initial code may keep these simple, but the boundaries should stay visible:
 - inquiry hooks: question breakdown, possible explanations, evidence checks, counter-view, next better question
 - research inquiry hooks: source metadata, source-backed claims, no-source fallback, data-to-check prompts
 - weekly hooks: current-local-week market story, current-week journal summary, next-week check questions
+- calendar hooks: local-date windows for today/yesterday/this-week/last-week and explicit review shortcuts
 - feedback hooks: claim extraction, thesis typing, evidence checks, counter-view, next question, concept linking
 - renderer hooks: terminal, compact, markdown, JSON
 - memory hooks: JSONL first, SQLite later if needed
@@ -39,8 +40,8 @@ Adapters should call the standalone `mp` CLI instead of making the core depend o
 
 Planned or current adapters:
 
-- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp week`, `$mp regime`, `$mp think ...`, `$mp review`
-- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp week`, `/mp regime`, `/mp think ...`, `/mp review`
+- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp week`, `$mp calendar`, `$mp regime`, `$mp think ...`, `$mp review`
+- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp week`, `/mp calendar`, `/mp regime`, `/mp think ...`, `/mp review`
 - OMX hook: optional compact pulse at session start or long task completion
 - tmux popup/status: optional compact pulse
 - cron/launchd: optional scheduled snapshots

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,9 +30,10 @@ Initial code may keep these simple, but the boundaries should stay visible:
 - research inquiry hooks: source metadata, source-backed claims, no-source fallback, data-to-check prompts
 - weekly hooks: current-local-week market story, current-week journal summary, next-week check questions
 - calendar hooks: local-date windows for today/yesterday/this-week/last-week and explicit review shortcuts
+- recall hooks: local journal full-text search, date/window filters, match snippets, recurring themes, next recall question
 - feedback hooks: claim extraction, thesis typing, evidence checks, counter-view, next question, concept linking
 - renderer hooks: terminal, compact, markdown, JSON
-- memory hooks: JSONL first, SQLite later if needed
+- memory hooks: JSONL first, local journal recall/search, SQLite later if needed
 
 ## Environment adapters
 
@@ -40,8 +41,8 @@ Adapters should call the standalone `mp` CLI instead of making the core depend o
 
 Planned or current adapters:
 
-- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp week`, `$mp calendar`, `$mp regime`, `$mp think ...`, `$mp review`
-- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp week`, `/mp calendar`, `/mp regime`, `/mp think ...`, `/mp review`
+- Codex skill: `$mp <question>`, `$mp ask ...`, `$mp research ...`, `$mp now`, `$mp week`, `$mp calendar`, `$mp regime`, `$mp think ...`, `$mp review`, `$mp find ...`
+- Claude Code slash command: `/mp <question>`, `/mp ask ...`, `/mp research ...`, `/mp now`, `/mp week`, `/mp calendar`, `/mp regime`, `/mp think ...`, `/mp review`, `/mp find ...`
 - OMX hook: optional compact pulse at session start or long task completion
 - tmux popup/status: optional compact pulse
 - cron/launchd: optional scheduled snapshots

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ Initial code may keep these simple, but the boundaries should stay visible:
 - lens hooks: risk-on/off, rates vs growth, dollar liquidity, Korea market, AI/semis, IPO/event, positioning/flow
 - inquiry hooks: question breakdown, possible explanations, evidence checks, counter-view, next better question
 - research inquiry hooks: source metadata, source-backed claims, no-source fallback, data-to-check prompts
-- weekly hooks: rolling 1W market story, 7-local-day journal summary, next-week check questions
+- weekly hooks: current-local-week market story, current-week journal summary, next-week check questions
 - feedback hooks: claim extraction, thesis typing, evidence checks, counter-view, next question, concept linking
 - renderer hooks: terminal, compact, markdown, JSON
 - memory hooks: JSONL first, SQLite later if needed

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -70,7 +70,8 @@ Acceptance criteria:
 
 - Reads recent JSONL journal events.
 - Supports `--date YYYY-MM-DD` to filter by the timestamp date stored in journal entries.
-- Applies `--limit N` after date matching when both are provided, keeping the most recent matching entries.
+- Supports `--ago N` / `--days-ago N` for common relative-day lookup without broad natural-language parsing.
+- Applies `--limit N` after date matching when combined with `--date` or `--ago`, keeping the most recent matching entries.
 - Shows a distinct empty-date message when no entries match the requested date.
 - Surfaces repeated themes, concepts, inquiry counts, and question/thesis habits.
 - Suggests one reasoning drill.

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -70,8 +70,8 @@ Acceptance criteria:
 
 - Reads recent JSONL journal events.
 - Supports `--date YYYY-MM-DD` to filter by the timestamp date stored in journal entries.
-- Supports `--ago N` / `--days-ago N` for common relative-day lookup without broad natural-language parsing.
-- Applies `--limit N` after date matching when combined with `--date` or `--ago`, keeping the most recent matching entries.
+- Supports preferred `--days N` plus compatibility `--ago N` / `--days-ago N` for common relative-day lookup without broad natural-language parsing.
+- Applies `--limit N` after date matching when combined with `--date` or `--days`, keeping the most recent matching entries.
 - Shows a distinct empty-date message when no entries match the requested date.
 - Surfaces repeated themes, concepts, inquiry counts, and question/thesis habits.
 - Suggests one reasoning drill.

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -84,6 +84,17 @@ Acceptance criteria:
 - Saves both thought and feedback unless `--no-save` is passed.
 - Avoids trading advice.
 
+### `mp find "query"`
+
+Acceptance criteria:
+
+- Searches local JSONL journal entries by explicit query.
+- Supports `--date YYYY-MM-DD`, `--days N`, `--today`, `--yesterday`, `--this-week`, `--last-week`, and `--limit N`.
+- Uses the same single-selector conflict rule as `mp review`.
+- Renders a recall card with query, filter basis, matching entries, matched event counts, recurring themes, next recall question, and a local-journal-only boundary.
+- Shows a helpful empty result when no entries match.
+- Avoids fuzzy natural-language date parsing, exchange calendars, live provider changes, semantic/vector search, and trading advice.
+
 ### `mp review`
 
 Acceptance criteria:

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -41,7 +41,7 @@ Acceptance criteria:
 
 - Prints a compact market card.
 - Includes mood, explicit quote/change basis, assets, drivers, tensions, question seeds / market puzzle prompts, and concept.
-- Uses a quote-session basis by default: local timestamp/session label plus latest Yahoo `regularMarketPrice` vs `chartPreviousClose` / fallback prior daily close from `range=5d&interval=1d`; this is not an exact 24-hour, local calendar-day, or weekly return view.
+- Uses a close-to-close basis by default: local timestamp/session label plus latest Yahoo daily close value vs prior daily close from `range=5d&interval=1d`, with `regularMarketPrice` as fallback only; this is not a high/low gap, exact 24-hour, local calendar-day, or weekly return view.
 - Saves a `pulse` journal event unless `--no-save` is passed.
 - Does not block the loop if live quote fetch fails.
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -50,7 +50,7 @@ Acceptance criteria:
 Acceptance criteria:
 
 - Prints a hybrid weekly market-and-learning card distinct from `mp now` and `mp regime`.
-- Uses a current-week market basis by default: local timestamp plus latest Yahoo `regularMarketPrice` vs the first close matching the current local calendar week from `range=1mo&interval=1d`, falling back to the latest available close if the asset has not traded this week.
+- Uses a current-week market basis by default: local timestamp plus latest Yahoo daily close value vs the first close matching the current local calendar week from `range=1mo&interval=1d`, with `regularMarketPrice` as fallback only and latest-close fallback if the asset has not traded this week.
 - Scans the current local calendar week of JSONL journal entries before saving the weekly card.
 - Includes weekly story, explicit basis, 1W asset map, weekly market themes, tensions, journal theme counts, thesis habits, next-week check questions, and a weekly drill.
 - Saves a `week` journal event unless `--no-save` is passed.
@@ -70,7 +70,7 @@ Acceptance criteria:
 Acceptance criteria:
 
 - Prints a broader market regime card distinct from `mp now`.
-- Uses a 1-3 month basis by default: local timestamp plus latest Yahoo `regularMarketPrice` vs first available close from `range=3mo&interval=1wk`.
+- Uses a 1-3 month basis by default: local timestamp plus latest Yahoo weekly close value vs first available weekly close from `range=3mo&interval=1wk`, with `regularMarketPrice` as fallback only.
 - Includes regime label, explicit basis, cross-asset map, regime drivers, tensions, checks, and next better regime question.
 - Saves a `regime` journal event unless `--no-save` is passed.
 - Avoids trading advice.

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -40,7 +40,8 @@ Acceptance criteria:
 Acceptance criteria:
 
 - Prints a compact market card.
-- Includes mood, assets, drivers, tensions, question seeds / market puzzle prompts, and concept.
+- Includes mood, explicit quote/change basis, assets, drivers, tensions, question seeds / market puzzle prompts, and concept.
+- Uses a session/daily basis by default: local timestamp/session label plus latest Yahoo `regularMarketPrice` vs `chartPreviousClose` from `range=5d&interval=1d`; this is not a weekly return view.
 - Saves a `pulse` journal event unless `--no-save` is passed.
 - Does not block the loop if live quote fetch fails.
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -41,7 +41,7 @@ Acceptance criteria:
 
 - Prints a compact market card.
 - Includes mood, explicit quote/change basis, assets, drivers, tensions, question seeds / market puzzle prompts, and concept.
-- Uses a session/daily basis by default: local timestamp/session label plus latest Yahoo `regularMarketPrice` vs `chartPreviousClose` from `range=5d&interval=1d`; this is not a weekly return view.
+- Uses a quote-session basis by default: local timestamp/session label plus latest Yahoo `regularMarketPrice` vs `chartPreviousClose` / fallback prior daily close from `range=5d&interval=1d`; this is not an exact 24-hour, local calendar-day, or weekly return view.
 - Saves a `pulse` journal event unless `--no-save` is passed.
 - Does not block the loop if live quote fetch fails.
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -56,6 +56,15 @@ Acceptance criteria:
 - Saves a `week` journal event unless `--no-save` is passed.
 - Avoids trading advice.
 
+### `mp calendar`
+
+Acceptance criteria:
+
+- Prints local-date windows for `today`, `yesterday`, `this-week`, and `last-week`.
+- Shows the matching `mp review` shortcut commands.
+- Names the boundary that these windows are local-date helpers, not exchange-holiday calendars or trading signals.
+- Does not save a journal event.
+
 ### `mp regime`
 
 Acceptance criteria:
@@ -82,8 +91,10 @@ Acceptance criteria:
 - Reads recent JSONL journal events.
 - Supports `--date YYYY-MM-DD` to filter by the timestamp date stored in journal entries.
 - Supports preferred `--days N` plus compatibility `--ago N` / `--days-ago N` for common relative-day lookup without broad natural-language parsing.
-- Applies `--limit N` after date matching when combined with `--date` or `--days`, keeping the most recent matching entries.
-- Shows a distinct empty-date message when no entries match the requested date.
+- Supports small calendar aliases: `--today`, `--yesterday`, `--this-week`, and `--last-week`.
+- Rejects multiple date/window selectors in the same review command.
+- Applies `--limit N` after date/window matching when combined with a selector, keeping the most recent matching entries.
+- Shows a distinct empty-date or empty-period message when no entries match the requested selector.
 - Surfaces repeated themes, concepts, inquiry counts, and question/thesis habits.
 - Suggests one reasoning drill.
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -45,6 +45,17 @@ Acceptance criteria:
 - Saves a `pulse` journal event unless `--no-save` is passed.
 - Does not block the loop if live quote fetch fails.
 
+### `mp week`
+
+Acceptance criteria:
+
+- Prints a hybrid weekly market-and-learning card distinct from `mp now` and `mp regime`.
+- Uses a rolling weekly market basis by default: local timestamp plus latest Yahoo `regularMarketPrice` vs first available close from `range=5d&interval=1d`.
+- Scans the last 7 local dates of JSONL journal entries before saving the weekly card.
+- Includes weekly story, explicit basis, 1W asset map, weekly market themes, tensions, journal theme counts, thesis habits, next-week check questions, and a weekly drill.
+- Saves a `week` journal event unless `--no-save` is passed.
+- Avoids trading advice.
+
 ### `mp regime`
 
 Acceptance criteria:

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -45,6 +45,16 @@ Acceptance criteria:
 - Saves a `pulse` journal event unless `--no-save` is passed.
 - Does not block the loop if live quote fetch fails.
 
+### `mp regime`
+
+Acceptance criteria:
+
+- Prints a broader market regime card distinct from `mp now`.
+- Uses a 1-3 month basis by default: local timestamp plus latest Yahoo `regularMarketPrice` vs first available close from `range=3mo&interval=1wk`.
+- Includes regime label, explicit basis, cross-asset map, regime drivers, tensions, checks, and next better regime question.
+- Saves a `regime` journal event unless `--no-save` is passed.
+- Avoids trading advice.
+
 ### `mp think "..."`
 
 Acceptance criteria:
@@ -85,5 +95,6 @@ Acceptance criteria:
 - built-in live RSS/SEC/news network providers
 - built-in Brave/Tavily/NewsAPI/SerpApi/Alpha Vantage/FRED integrations
 - article body storage or summarization
+- date-based journal lookup/search such as `mp review --date YYYY-MM-DD`
 - external plugin loading
 - paid data vendors

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -69,6 +69,9 @@ Acceptance criteria:
 Acceptance criteria:
 
 - Reads recent JSONL journal events.
+- Supports `--date YYYY-MM-DD` to filter by the timestamp date stored in journal entries.
+- Applies `--limit N` after date matching when both are provided, keeping the most recent matching entries.
+- Shows a distinct empty-date message when no entries match the requested date.
 - Surfaces repeated themes, concepts, inquiry counts, and question/thesis habits.
 - Suggests one reasoning drill.
 
@@ -95,6 +98,5 @@ Acceptance criteria:
 - built-in live RSS/SEC/news network providers
 - built-in Brave/Tavily/NewsAPI/SerpApi/Alpha Vantage/FRED integrations
 - article body storage or summarization
-- date-based journal lookup/search such as `mp review --date YYYY-MM-DD`
 - external plugin loading
 - paid data vendors

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -50,8 +50,8 @@ Acceptance criteria:
 Acceptance criteria:
 
 - Prints a hybrid weekly market-and-learning card distinct from `mp now` and `mp regime`.
-- Uses a rolling weekly market basis by default: local timestamp plus latest Yahoo `regularMarketPrice` vs first available close from `range=5d&interval=1d`.
-- Scans the last 7 local dates of JSONL journal entries before saving the weekly card.
+- Uses a current-week market basis by default: local timestamp plus latest Yahoo `regularMarketPrice` vs the first close matching the current local calendar week from `range=1mo&interval=1d`, falling back to the latest available close if the asset has not traded this week.
+- Scans the current local calendar week of JSONL journal entries before saving the weekly card.
 - Includes weekly story, explicit basis, 1W asset map, weekly market themes, tensions, journal theme counts, thesis habits, next-week check questions, and a weekly drill.
 - Saves a `week` journal event unless `--no-save` is passed.
 - Avoids trading advice.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,22 +1330,33 @@ fn infer_week_tensions(assets: &[Asset], label: &str) -> Vec<String> {
 
 fn infer_week_questions(assets: &[Asset], label: &str, tensions: &[String]) -> Vec<String> {
     let text = format!("{label} {}", tensions.join(" ")).to_lowercase();
-    let mut questions = Vec::new();
-    if text.contains("financial-condition") || text.contains("rates") {
-        questions.push("Next week, do yields/dollar confirm or fight the equity story?".into());
+    let mut tags = detect_tags(&text);
+    if text.contains("financial-condition")
+        || text.contains("rates")
+        || change_for(assets, "^TNX").is_some()
+    {
+        push_tag(&mut tags, "rates");
     }
-    if text.contains("nasdaq") || text.contains("growth") {
-        questions.push("Is leadership broadening beyond growth/AI, or still narrow?".into());
+    if text.contains("nasdaq") || text.contains("growth") || text.contains("ai") {
+        push_tag(&mut tags, "semis");
     }
     if text.contains("korea") || change_for(assets, "^KS11").is_some() {
-        questions
-            .push("Does KOSPI confirm the US story, or is FX/EM pressure still a drag?".into());
+        push_tag(&mut tags, "korea");
+    }
+    if text.contains("fx")
+        || text.contains("dollar")
+        || change_for(assets, "DX-Y.NYB").is_some()
+        || change_for(assets, "KRW=X").is_some()
+    {
+        push_tag(&mut tags, "fx");
     }
     if text.contains("oil") || change_for(assets, "CL=F").is_some_and(|v| v.abs() > 4.0) {
-        questions
-            .push("Is oil changing inflation expectations, or staying sector-specific?".into());
+        push_tag(&mut tags, "oil");
     }
-    questions.push("What would make you rename this week’s market story by next Friday?".into());
+    let mut questions = validation_questions(&tags);
+    questions.push(
+        "By next Friday, what evidence would force you to rename this week’s market story?".into(),
+    );
     let mut unique = Vec::new();
     for question in questions {
         if !unique.contains(&question) {
@@ -1762,37 +1773,114 @@ fn counters(tags: &[&str]) -> Vec<String> {
     v
 }
 
-fn next_questions(tags: &[&str]) -> Vec<String> {
+fn push_tag(tags: &mut Vec<&'static str>, tag: &'static str) {
+    if !tags.contains(&tag) {
+        tags.push(tag);
+    }
+}
+
+fn validation_questions(tags: &[&str]) -> Vec<String> {
     let mut v = Vec::new();
     if tags.contains(&"rates") && tags.contains(&"semis") {
-        v.push("If yields rise further, do semis still outperform the broad market?".into());
+        v.push("What evidence would prove growth leadership is absorbing rate pressure rather than just ignoring it for one session?".into());
+        v.push("What would falsify the rates/growth story: higher yields with semis still leading, or lower yields with weak breadth?".into());
+        v.push("What alternative fits the same tape better: earnings momentum, liquidity, positioning, or genuine easing expectations?".into());
     } else if tags.contains(&"rates") {
-        v.push("If this is really easing expectations, should growth assets, the dollar, and yields confirm together?".into());
+        v.push(
+            "What would confirm this is easing expectations rather than growth-scare bond buying?"
+                .into(),
+        );
+        v.push("What would falsify the rates story if yields, dollar, and growth assets stop confirming each other?".into());
     }
     if tags.contains(&"fx") && tags.contains(&"korea") {
-        v.push("Does KRW weakness coincide with foreign selling, or are exporters offsetting the pressure?".into());
+        v.push("What evidence would show FX is driving Korea risk rather than only translating a global move?".into());
+        v.push("What would falsify the FX-pressure read: KRW weakness without foreign selling, or exporters offsetting the drag?".into());
+    } else if tags.contains(&"fx") {
+        v.push("What would prove dollar strength is a market-wide liquidity signal rather than a local currency move?".into());
     }
     if tags.contains(&"oil") {
-        v.push("Is oil moving enough to change inflation expectations, or is it only a sector input today?".into());
+        v.push("What evidence would show oil is changing inflation expectations instead of staying sector-specific?".into());
     }
     if tags.contains(&"event") {
-        v.push("What market segment should move first if the IPO/event explanation is actually driving the session?".into());
+        v.push("What should move first if the IPO/listing/event explanation is actually driving the session?".into());
+        v.push("What would falsify the event story: broad assets moving before the event, or unrelated sectors leading?".into());
     }
     if tags.contains(&"positioning") {
-        v.push("What would distinguish positioning from a real change in growth, rates, or earnings expectations?".into());
+        v.push("What would distinguish positioning or flow from a real change in growth, rates, or earnings expectations?".into());
     }
     if v.is_empty() {
-        v.push(
-            "What would you need to see by the close to say this interpretation was wrong?".into(),
-        );
+        v.push("What evidence would confirm this interpretation, and what single observation would make it wrong?".into());
+        v.push("What alternative explanation could fit the same price action without forcing a one-cause story?".into());
     }
-    v
+    let mut unique = Vec::new();
+    for question in v {
+        if !unique.contains(&question) {
+            unique.push(question);
+        }
+    }
+    unique.truncate(4);
+    unique
+}
+
+fn next_questions(tags: &[&str]) -> Vec<String> {
+    validation_questions(tags)
 }
 
 fn next_better_question(tags: &[&str]) -> String {
-    next_questions(tags).into_iter().next().unwrap_or_else(|| {
-        "What evidence would make this market interpretation wrong by the close?".into()
-    })
+    validation_questions(tags)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| {
+            "What evidence would confirm this interpretation, and what would make it wrong?".into()
+        })
+}
+
+fn tags_from_summary(summary: &JournalSummary, limit: usize) -> Vec<&'static str> {
+    summary
+        .tag_counts
+        .iter()
+        .filter(|(_, count)| *count > 0)
+        .take(limit)
+        .map(|(tag, _)| *tag)
+        .collect()
+}
+
+fn recall_question(query: &str, filter: &str, tags: &[&str]) -> String {
+    if tags.contains(&"rates") {
+        return format!(
+            "In {filter}, were your old \"{query}\" notes assuming easing, growth scare, or rate pressure—and which current yield/dollar move would falsify that read?"
+        );
+    }
+    if tags.contains(&"fx") || tags.contains(&"korea") {
+        return format!(
+            "In {filter}, did \"{query}\" mean global dollar pressure, Korea-specific stress, or sector rotation—and what current evidence would disprove it?"
+        );
+    }
+    if tags.contains(&"event") || tags.contains(&"positioning") {
+        return format!(
+            "In {filter}, was \"{query}\" an event/flow explanation or a durable market signal—and what would prove that old read was just timing noise?"
+        );
+    }
+    if tags.contains(&"oil") {
+        return format!(
+            "In {filter}, did \"{query}\" point to inflation pressure, demand, or sector rotation—and what would falsify that channel now?"
+        );
+    }
+    format!(
+        "In {filter}, what changed since you last wrote about \"{query}\", and what evidence would falsify that old interpretation now?"
+    )
+}
+
+fn review_drill(summary: &JournalSummary) -> String {
+    let tags = tags_from_summary(summary, 2);
+    let focus = if tags.is_empty() {
+        "your next repeated theme".to_string()
+    } else {
+        tags.join(" + ")
+    };
+    format!(
+        "\nSuggested drill\n  For the next 3 notes, run a validation loop on {focus}:\n  1. claim: what market story am I telling?\n  2. confirming evidence: which asset/event should move next if I am right?\n  3. alternative: what else could explain the same tape?\n  4. falsifier: what observation would make me rename the view?"
+    )
 }
 
 fn concepts(tags: &[&str]) -> Vec<String> {
@@ -2502,7 +2590,7 @@ fn render_find_from_events(
     let mut wrote_theme = false;
     for (tag, count) in summary
         .tag_counts
-        .into_iter()
+        .iter()
         .filter(|(_, count)| *count > 0)
         .take(4)
     {
@@ -2512,8 +2600,13 @@ fn render_find_from_events(
     if !wrote_theme {
         out.push_str("  - Not enough tagged matching entries yet\n");
     }
+    let mut recall_tags = detect_tags(query);
+    for tag in tags_from_summary(&summary, 2) {
+        push_tag(&mut recall_tags, tag);
+    }
+    let question = recall_question(query, &filter, &recall_tags);
     out.push_str(&format!(
-        "\nNext recall question\n  What changed since you last wrote about \"{query}\", and what would falsify that old interpretation now?\n\nBoundary\n  `mp find` searches your local journal only. It is recall support for market literacy, not live research or trading advice."
+        "\nNext recall question\n  {question}\n\nBoundary\n  `mp find` searches your local journal only. It is recall support for market literacy, not live research or trading advice."
     ));
     out
 }
@@ -2625,12 +2718,7 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
     let summary = summarize_events(events);
     let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), summary.pulses, summary.weeks, summary.regimes, summary.inquiries, summary.research_inquiries, summary.thoughts, summary.feedback);
     let mut wrote = false;
-    for (tag, count) in summary
-        .tag_counts
-        .into_iter()
-        .filter(|(_, c)| *c > 0)
-        .take(6)
-    {
+    for (tag, count) in summary.tag_counts.iter().filter(|(_, c)| *c > 0).take(6) {
         wrote = true;
         out.push_str(&format!("  - {tag}: {count}\n"));
     }
@@ -2645,7 +2733,7 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
             out.push_str(&format!("  - You have been using a {t} lens.\n"));
         }
     }
-    out.push_str("\nSuggested drill\n  For the next 3 notes, explicitly separate:\n  1. market-wide signal\n  2. sector-specific signal\n  3. event/positioning alternative\n  4. what would falsify the view");
+    out.push_str(&review_drill(&summary));
     out
 }
 
@@ -3091,6 +3179,8 @@ mod tests {
         assert!(f.thesis_type.contains("rates/growth"));
         assert!(f.counter.iter().any(|x| x.contains("Semis strength")));
         assert!(f.check.iter().any(|x| x.to_lowercase().contains("yields")));
+        assert!(f.next.iter().any(|x| x.contains("What evidence")));
+        assert!(f.next.iter().any(|x| x.contains("falsify")));
     }
 
     #[test]
@@ -3116,6 +3206,9 @@ mod tests {
         assert!(out.contains("Question / thesis habits"));
         assert!(out.contains("event"));
         assert!(out.contains("rates"));
+        assert!(out.contains("validation loop"));
+        assert!(out.contains("alternative"));
+        assert!(out.contains("falsifier"));
     }
 
     #[test]
@@ -3283,6 +3376,8 @@ mod tests {
         assert!(out.contains("Query: \"금리\""));
         assert!(out.contains("Entries matched: 2"));
         assert!(out.contains("Next recall question"));
+        assert!(out.contains("this-week 2026-04-20..2026-04-21"));
+        assert!(out.contains("yield/dollar"));
         assert!(out.contains("local journal only"));
         assert!(out.contains("not live research or trading advice"));
     }
@@ -3467,6 +3562,8 @@ mod tests {
         assert!(rendered.contains("This week's learning loop"));
         assert!(rendered.contains("Recurring journal themes"));
         assert!(rendered.contains("Next week check questions"));
+        assert!(rendered.contains("evidence"));
+        assert!(rendered.contains("rename this week"));
         assert!(rendered.contains("rates"));
         assert!(rendered.contains("not investment advice"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1598,7 +1598,7 @@ fn make_inquiry(question: &str, linked: Option<String>) -> Inquiry {
         explanations: possible_explanations(&tags),
         evidence: evidence_checks(&tags),
         counter: counters(&tags),
-        next_question: next_better_question(&tags),
+        next_question: next_better_question_for(&tags, question),
         concepts: concepts(&tags),
         thesis_type,
     }
@@ -1692,7 +1692,7 @@ fn make_feedback(text: &str, linked: Option<String>) -> Feedback {
         good: good(&tags),
         check: evidence_checks(&tags),
         counter: counters(&tags),
-        next: next_questions(&tags),
+        next: next_questions_for(&tags, text),
         concepts: concepts(&tags),
     }
 }
@@ -1778,7 +1778,53 @@ fn push_tag(tags: &mut Vec<&'static str>, tag: &'static str) {
     }
 }
 
-fn validation_questions(tags: &[&str]) -> Vec<String> {
+fn contains_hangul(text: &str) -> bool {
+    text.chars().any(|ch| {
+        ('가'..='힣').contains(&ch) || ('ㄱ'..='ㅎ').contains(&ch) || ('ㅏ'..='ㅣ').contains(&ch)
+    })
+}
+
+fn validation_questions_for(tags: &[&str], korean: bool) -> Vec<String> {
+    if korean {
+        return korean_validation_questions(tags);
+    }
+    english_validation_questions(tags)
+}
+
+fn korean_validation_questions(tags: &[&str]) -> Vec<String> {
+    let mut v = Vec::new();
+    if tags.contains(&"rates") && tags.contains(&"semis") {
+        v.push("성장주 강세가 금리 부담을 흡수한다는 증거는 뭐지?".into());
+        v.push("이 금리/성장주 해석을 틀리게 만들 신호는 뭐지?".into());
+        v.push("실적, 유동성, 수급, 완화 기대 중 대안가설은 뭐지?".into());
+    } else if tags.contains(&"rates") {
+        v.push("완화 기대인지 성장 둔화 매수인지 구분할 증거는 뭐지?".into());
+        v.push("금리·달러·성장주가 엇갈리면 이 해석은 어떻게 깨지지?".into());
+    }
+    if tags.contains(&"fx") && tags.contains(&"korea") {
+        v.push("환율이 한국 리스크를 주도한다는 증거는 뭐지?".into());
+        v.push("원화 약세에도 외국인 매도나 지수 약세가 없으면 어떻게 볼까?".into());
+    } else if tags.contains(&"fx") {
+        v.push("달러 강세가 전반적 유동성 신호라는 증거는 뭐지?".into());
+    }
+    if tags.contains(&"oil") {
+        v.push("유가가 인플레 기대를 바꾸고 있다는 증거는 뭐지?".into());
+    }
+    if tags.contains(&"event") {
+        v.push("상장/이벤트가 원인이면 어떤 자산이 먼저 움직여야 하지?".into());
+        v.push("이벤트 설명을 틀리게 만들 반대 신호는 뭐지?".into());
+    }
+    if tags.contains(&"positioning") {
+        v.push("수급/포지셔닝과 진짜 펀더멘털 변화를 어떻게 구분하지?".into());
+    }
+    if v.is_empty() {
+        v.push("이 해석을 확인할 증거와 틀리게 만들 관찰은 뭐지?".into());
+        v.push("같은 움직임을 설명할 다른 가설은 뭐지?".into());
+    }
+    dedupe_and_limit(v, 4)
+}
+
+fn english_validation_questions(tags: &[&str]) -> Vec<String> {
     let mut v = Vec::new();
     if tags.contains(&"rates") && tags.contains(&"semis") {
         v.push("What evidence shows growth leadership is absorbing rate pressure?".into());
@@ -1816,26 +1862,39 @@ fn validation_questions(tags: &[&str]) -> Vec<String> {
         v.push("What evidence confirms this view, and what observation makes it wrong?".into());
         v.push("What alternative explains the same tape without a one-cause story?".into());
     }
+    dedupe_and_limit(v, 4)
+}
+
+fn dedupe_and_limit(questions: Vec<String>, limit: usize) -> Vec<String> {
     let mut unique = Vec::new();
-    for question in v {
+    for question in questions {
         if !unique.contains(&question) {
             unique.push(question);
         }
     }
-    unique.truncate(4);
+    unique.truncate(limit);
     unique
 }
 
-fn next_questions(tags: &[&str]) -> Vec<String> {
-    validation_questions(tags)
+fn validation_questions(tags: &[&str]) -> Vec<String> {
+    validation_questions_for(tags, false)
 }
 
-fn next_better_question(tags: &[&str]) -> String {
-    validation_questions(tags)
+fn next_questions_for(tags: &[&str], source_text: &str) -> Vec<String> {
+    validation_questions_for(tags, contains_hangul(source_text))
+}
+
+fn next_better_question_for(tags: &[&str], source_text: &str) -> String {
+    validation_questions_for(tags, contains_hangul(source_text))
         .into_iter()
         .next()
         .unwrap_or_else(|| {
-            "What evidence would confirm this interpretation, and what would make it wrong?".into()
+            if contains_hangul(source_text) {
+                "이 해석을 확인할 증거와 틀리게 만들 관찰은 뭐지?".into()
+            } else {
+                "What evidence would confirm this interpretation, and what would make it wrong?"
+                    .into()
+            }
         })
 }
 
@@ -1850,6 +1909,31 @@ fn tags_from_summary(summary: &JournalSummary, limit: usize) -> Vec<&'static str
 }
 
 fn recall_question(query: &str, filter: &str, tags: &[&str]) -> String {
+    if contains_hangul(query) {
+        if tags.contains(&"rates") {
+            return format!(
+                "기간({filter}) 기준으로 예전 \"{query}\" 메모는 완화 기대/성장 둔화/금리 부담 중 뭐였고, 어떤 금리·달러 움직임이 그 해석을 깨지?"
+            );
+        }
+        if tags.contains(&"fx") || tags.contains(&"korea") {
+            return format!(
+                "기간({filter}) 기준으로 \"{query}\"는 달러 압력/한국 리스크/섹터 로테이션 중 뭐였고, 어떤 증거가 그 해석을 반박하지?"
+            );
+        }
+        if tags.contains(&"event") || tags.contains(&"positioning") {
+            return format!(
+                "기간({filter}) 기준으로 \"{query}\"는 이벤트·수급인지 지속 신호인지, 무엇이 시간차 노이즈였음을 보여주지?"
+            );
+        }
+        if tags.contains(&"oil") {
+            return format!(
+                "기간({filter}) 기준으로 \"{query}\"는 인플레/수요/섹터 회전 중 뭐였고, 무엇이 그 경로를 깨지?"
+            );
+        }
+        return format!(
+            "기간({filter}) 기준으로 \"{query}\"를 썼던 때와 지금 무엇이 달라졌고, 어떤 증거가 그 해석을 깨지?"
+        );
+    }
     if tags.contains(&"rates") {
         return format!(
             "In {filter}, did old \"{query}\" notes assume easing, growth scare, or rate pressure—and which yield/dollar move would falsify that read?"
@@ -1878,10 +1962,19 @@ fn recall_question(query: &str, filter: &str, tags: &[&str]) -> String {
 fn review_drill(summary: &JournalSummary) -> String {
     let tags = tags_from_summary(summary, 2);
     let focus = if tags.is_empty() {
-        "your next repeated theme".to_string()
+        if summary.korean_entries > 0 {
+            "다음 반복 테마".to_string()
+        } else {
+            "your next repeated theme".to_string()
+        }
     } else {
         tags.join(" + ")
     };
+    if summary.korean_entries > 0 {
+        return format!(
+            "\nSuggested drill\n  다음 3개 메모에서 {focus}를 검증 루프로 나눠보세요:\n  1. 주장: 내가 말하는 시장 스토리는?\n  2. 증거: 맞다면 다음에 무엇이 움직여야 하지?\n  3. 대안: 같은 흐름을 설명할 다른 가설은?\n  4. 반증: 무엇이 나오면 이 해석을 바꿔야 하지?"
+        );
+    }
     format!(
         "\nSuggested drill\n  For the next 3 notes, run a validation loop on {focus}:\n  1. claim: what story am I telling?\n  2. evidence: what should move next if I am right?\n  3. alternative: what else explains the same tape?\n  4. falsifier: what would make me rename the view?"
     )
@@ -2655,6 +2748,7 @@ struct JournalSummary {
     feedback: usize,
     tag_counts: Vec<(&'static str, usize)>,
     thesis_types: Vec<String>,
+    korean_entries: usize,
 }
 
 fn summarize_events(events: &[String]) -> JournalSummary {
@@ -2676,6 +2770,7 @@ fn summarize_events(events: &[String]) -> JournalSummary {
         ("positioning", 0),
     ];
     let mut thesis_types = Vec::new();
+    let mut korean_entries = 0usize;
     for line in events.iter().filter(|l| {
         l.contains("\"type\":\"thought\"")
             || l.contains("\"type\":\"inquiry\"")
@@ -2684,6 +2779,9 @@ fn summarize_events(events: &[String]) -> JournalSummary {
         let text = json_field(line, "text")
             .or_else(|| json_field(line, "question"))
             .unwrap_or_default();
+        if contains_hangul(&text) {
+            korean_entries += 1;
+        }
         let tags = detect_tags(&text);
         if !tags.is_empty() {
             thesis_types.push(detect_thesis_type(&tags));
@@ -2707,6 +2805,7 @@ fn summarize_events(events: &[String]) -> JournalSummary {
         feedback,
         tag_counts,
         thesis_types,
+        korean_entries,
     }
 }
 
@@ -3183,8 +3282,8 @@ mod tests {
         assert!(f.thesis_type.contains("rates/growth"));
         assert!(f.counter.iter().any(|x| x.contains("Semis strength")));
         assert!(f.check.iter().any(|x| x.to_lowercase().contains("yields")));
-        assert!(f.next.iter().any(|x| x.contains("What evidence")));
-        assert!(f.next.iter().any(|x| x.contains("falsify")));
+        assert!(f.next.iter().any(|x| x.contains("증거")));
+        assert!(f.next.iter().any(|x| x.contains("틀리게")));
     }
 
     #[test]
@@ -3210,9 +3309,9 @@ mod tests {
         assert!(out.contains("Question / thesis habits"));
         assert!(out.contains("event"));
         assert!(out.contains("rates"));
-        assert!(out.contains("validation loop"));
-        assert!(out.contains("alternative"));
-        assert!(out.contains("falsifier"));
+        assert!(out.contains("검증 루프"));
+        assert!(out.contains("대안"));
+        assert!(out.contains("반증"));
     }
 
     #[test]
@@ -3381,7 +3480,7 @@ mod tests {
         assert!(out.contains("Entries matched: 2"));
         assert!(out.contains("Next recall question"));
         assert!(out.contains("this-week 2026-04-20..2026-04-21"));
-        assert!(out.contains("yield/dollar"));
+        assert!(out.contains("금리·달러"));
         assert!(out.contains("local journal only"));
         assert!(out.contains("not live research or trading advice"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,8 +196,8 @@ enum CommandKind {
 
 const PULSE_QUOTE_BASIS: &[&str] = &[
     "time: local machine timestamp and session label",
-    "change: latest Yahoo regularMarketPrice vs chartPreviousClose, usually the prior regular-session close",
-    "window: Yahoo chart range=5d interval=1d; this is a session/daily pulse, not a weekly return",
+    "change: latest Yahoo regularMarketPrice vs chartPreviousClose/fallback prior daily close",
+    "window: Yahoo chart range=5d interval=1d; quote-session pulse, not exact 24h, calendar-day, or weekly return",
 ];
 
 const REGIME_QUOTE_BASIS: &[&str] = &[
@@ -837,7 +837,11 @@ fn build_pulse() -> Pulse {
             }
         }
     }
-    let mut notes = vec!["market quotes from Yahoo Finance chart endpoint via curl".to_string()];
+    let mut notes = vec![
+        "market quotes from Yahoo Finance chart endpoint via curl".to_string(),
+        "mixed sessions: US indices, Korea, FX, futures, and crypto can have different clocks; compare directionally"
+            .to_string(),
+    ];
     if failures > 0 {
         notes.push(format!(
             "{failures} quote(s) unavailable; kept the learning loop alive"
@@ -3580,7 +3584,8 @@ mod tests {
         let rendered = render_pulse(&p, false);
         assert!(rendered.contains("Market puzzle / question seeds"));
         assert!(rendered.contains("Basis"));
-        assert!(rendered.contains("not a weekly return"));
+        assert!(rendered.contains("quote-session pulse"));
+        assert!(rendered.contains("not exact 24h, calendar-day, or weekly return"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ struct Asset {
 struct Pulse {
     timestamp: String,
     session: String,
+    basis: Vec<String>,
     mood: String,
     assets: Vec<Asset>,
     drivers: Vec<String>,
@@ -163,6 +164,12 @@ enum CommandKind {
     Inquiry { text: String, no_save: bool },
     Research { text: String, no_save: bool },
 }
+
+const PULSE_QUOTE_BASIS: &[&str] = &[
+    "time: local machine timestamp and session label",
+    "change: latest Yahoo regularMarketPrice vs chartPreviousClose, usually the prior regular-session close",
+    "window: Yahoo chart range=5d interval=1d; this is a session/daily pulse, not a weekly return",
+];
 
 const SYMBOLS: &[(&str, &str, &str)] = &[
     ("^GSPC", "S&P 500", ""),
@@ -530,6 +537,7 @@ fn build_pulse() -> Pulse {
     Pulse {
         timestamp: timestamp(),
         session: session(),
+        basis: PULSE_QUOTE_BASIS.iter().map(|s| (*s).to_string()).collect(),
         mood,
         assets,
         drivers,
@@ -1082,9 +1090,13 @@ fn render_pulse(p: &Pulse, compact: bool) -> String {
         );
     }
     let mut out = format!(
-        "Market Pulse · {} · {}\n\nMood\n  {}\n\nAssets\n",
+        "Market Pulse · {} · {}\n\nMood\n  {}\n\nBasis\n",
         p.timestamp, p.session, p.mood
     );
+    for b in &p.basis {
+        out.push_str(&format!("  - {b}\n"));
+    }
+    out.push_str("\nAssets\n");
     for a in &p.assets {
         let value = a
             .value
@@ -1467,7 +1479,15 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
 }
 
 fn pulse_json(p: &Pulse) -> String {
-    format!("{{\"type\":\"pulse\",\"timestamp\":\"{}\",\"session\":\"{}\",\"mood\":\"{}\",\"question\":\"{}\",\"concept\":\"{}\"}}", esc(&p.timestamp), esc(&p.session), esc(&p.mood), esc(&p.question), esc(&p.concept))
+    format!(
+        "{{\"type\":\"pulse\",\"timestamp\":\"{}\",\"session\":\"{}\",\"basis\":\"{}\",\"mood\":\"{}\",\"question\":\"{}\",\"concept\":\"{}\"}}",
+        esc(&p.timestamp),
+        esc(&p.session),
+        esc(&p.basis.join(" | ")),
+        esc(&p.mood),
+        esc(&p.question),
+        esc(&p.concept)
+    )
 }
 
 fn thought_json(text: &str, linked: Option<&str>) -> String {
@@ -1893,7 +1913,10 @@ mod tests {
         assert!(p.tensions.iter().any(|t| t.contains("rates")));
         assert!(!p.question.is_empty());
         assert!(!question_seeds_for(&p).is_empty());
-        assert!(render_pulse(&p, false).contains("Market puzzle / question seeds"));
+        let rendered = render_pulse(&p, false);
+        assert!(rendered.contains("Market puzzle / question seeds"));
+        assert!(rendered.contains("Basis"));
+        assert!(rendered.contains("not a weekly return"));
     }
 
     fn compose_test_pulse(assets: Vec<Asset>) -> Pulse {
@@ -1909,6 +1932,7 @@ mod tests {
         Pulse {
             timestamp: timestamp(),
             session: session(),
+            basis: PULSE_QUOTE_BASIS.iter().map(|s| (*s).to_string()).collect(),
             question: infer_question(&tensions, &mood),
             concept: infer_concept(&tensions, &drivers),
             mood,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,12 +198,6 @@ const PULSE_QUOTE_BASIS: &[&str] = &[
     "window: Yahoo chart range=5d interval=1d; this is a session/daily pulse, not a weekly return",
 ];
 
-const WEEK_QUOTE_BASIS: &[&str] = &[
-    "time: local machine timestamp; weekly is a learning loop, not a trading signal",
-    "market window: Yahoo chart range=5d interval=1d, latest regularMarketPrice vs first available close",
-    "journal window: last 7 local dates from market-pulse JSONL, filtered before the weekly card is saved",
-];
-
 const REGIME_QUOTE_BASIS: &[&str] = &[
     "time: local machine timestamp; regime is broader than today's pulse",
     "change: latest Yahoo regularMarketPrice vs first available close in the chart window",
@@ -613,14 +607,60 @@ fn date_for_days_ago(days: u32) -> Result<String, String> {
         .ok_or_else(|| "--days needs BSD `date -v` or GNU `date -d` support".into())
 }
 
+fn current_week_date_prefixes() -> Vec<String> {
+    let Some(weekday) = iso_weekday() else {
+        return date_prefixes_for_days(7);
+    };
+    let mut dates = (0..weekday)
+        .filter_map(|days_ago| date_for_days_ago(days_ago).ok())
+        .collect::<Vec<_>>();
+    dates.reverse();
+    dates
+}
+
+fn iso_weekday() -> Option<u32> {
+    command_date_raw(&["+%u"])
+        .and_then(|raw| raw.parse::<u32>().ok())
+        .filter(|day| (1..=7).contains(day))
+}
+
+fn week_basis(dates: &[String]) -> Vec<String> {
+    let window = week_window_label(dates);
+    vec![
+        format!("time: local machine timestamp; current-week window {window}; weekly is a learning loop, not a trading signal"),
+        "market window: Yahoo chart range=1mo interval=1d; change is latest regularMarketPrice vs first close matching the current local week, falling back to the latest available close if the asset has not traded this week".into(),
+        format!("journal window: current local calendar week {window}, filtered before the weekly card is saved"),
+    ]
+}
+
+fn week_window_label(dates: &[String]) -> String {
+    match (dates.first(), dates.last()) {
+        (Some(first), Some(last)) if first == last => first.clone(),
+        (Some(first), Some(last)) => format!("{first}..{last}"),
+        _ => "unavailable".into(),
+    }
+}
+
+fn date_for_unix_timestamp(seconds: i64) -> Option<String> {
+    let raw = seconds.to_string();
+    command_date(&["-r", &raw, "+%Y-%m-%d"]).or_else(|| {
+        let gnu_timestamp = format!("@{raw}");
+        command_date(&["-d", &gnu_timestamp, "+%Y-%m-%d"])
+    })
+}
+
 fn command_date(args: &[&str]) -> Option<String> {
+    let date = command_date_raw(args)?;
+    validate_review_date(&date).ok()?;
+    Some(date)
+}
+
+fn command_date_raw(args: &[&str]) -> Option<String> {
     let output = Command::new("date").args(args).output().ok()?;
     if !output.status.success() {
         return None;
     }
-    let date = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    validate_review_date(&date).ok()?;
-    Some(date)
+    Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
 }
 
 fn validate_review_date(date: &str) -> Result<(), String> {
@@ -697,8 +737,16 @@ fn build_pulse() -> Pulse {
 fn build_week() -> Weekly {
     let mut assets = Vec::new();
     let mut failures = 0;
+    let week_dates = current_week_date_prefixes();
     for (symbol, label, unit) in SYMBOLS {
-        match fetch_asset_window(symbol, label, unit, "5d", "1d", WindowChange::FirstClose) {
+        match fetch_asset_window(
+            symbol,
+            label,
+            unit,
+            "1mo",
+            "1d",
+            WindowChange::FirstMatchingDate(week_dates.clone()),
+        ) {
             Ok(asset) => assets.push(asset),
             Err(_) => {
                 failures += 1;
@@ -715,7 +763,7 @@ fn build_week() -> Weekly {
     }
     let mut notes = vec![
         "weekly market window uses Yahoo Finance chart endpoint via curl".to_string(),
-        "weekly journal window is a rolling 7 local-date learning review".to_string(),
+        "weekly journal window uses the current local calendar week".to_string(),
     ];
     if failures > 0 {
         notes.push(format!(
@@ -735,7 +783,7 @@ fn build_week() -> Weekly {
     let questions = infer_week_questions(&assets, &label, &tensions);
     Weekly {
         timestamp: timestamp(),
-        basis: WEEK_QUOTE_BASIS.iter().map(|s| (*s).to_string()).collect(),
+        basis: week_basis(&week_dates),
         label,
         assets,
         drivers,
@@ -801,10 +849,11 @@ fn build_regime() -> Regime {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 enum WindowChange {
     PreviousClose,
     FirstClose,
+    FirstMatchingDate(Vec<String>),
 }
 
 fn fetch_asset(
@@ -849,6 +898,9 @@ fn fetch_asset_window(
         WindowChange::PreviousClose => number_after(&body, "\"chartPreviousClose\":")
             .or_else(|| closes.get(closes.len().saturating_sub(2)).copied()),
         WindowChange::FirstClose => closes.first().copied(),
+        WindowChange::FirstMatchingDate(dates) => first_close_for_dates(&body, &dates)
+            .or_else(|| number_after(&body, "\"chartPreviousClose\":"))
+            .or_else(|| closes.last().copied()),
     };
     let change = match (value, previous) {
         (Some(v), Some(p)) if p != 0.0 => Some(((v - p) / p) * 100.0),
@@ -892,6 +944,34 @@ fn close_values(text: &str) -> Vec<f64> {
         .split(',')
         .filter_map(|v| v.parse().ok())
         .collect()
+}
+
+fn timestamp_values(text: &str) -> Vec<i64> {
+    let Some(start_key) = text.find("\"timestamp\":[") else {
+        return vec![];
+    };
+    let start = start_key + "\"timestamp\":[".len();
+    let Some(end) = text[start..].find(']') else {
+        return vec![];
+    };
+    text[start..start + end]
+        .split(',')
+        .filter_map(|v| v.parse().ok())
+        .collect()
+}
+
+fn first_close_for_dates(text: &str, dates: &[String]) -> Option<f64> {
+    if dates.is_empty() {
+        return None;
+    }
+    timestamp_values(text)
+        .into_iter()
+        .zip(close_values(text))
+        .find_map(|(ts, close)| {
+            date_for_unix_timestamp(ts)
+                .filter(|date| dates.iter().any(|d| d == date))
+                .map(|_| close)
+        })
 }
 
 fn avg_change(assets: &[Asset], symbols: &[&str]) -> Option<f64> {
@@ -2026,7 +2106,7 @@ fn read_week_events(limit: usize) -> Vec<String> {
         return Vec::new();
     };
     let events = read_event_lines(&text);
-    let dates = date_prefixes_for_days(7);
+    let dates = current_week_date_prefixes();
     if dates.is_empty() {
         return limit_events(events, limit);
     }
@@ -2745,13 +2825,34 @@ mod tests {
         let events = vec![
             "{\"type\":\"thought\",\"timestamp\":\"2026-04-19T09:00:00+0900\",\"text\":\"유가\",\"linked_pulse_timestamp\":null}".into(),
             "{\"type\":\"thought\",\"timestamp\":\"2026-04-20T10:00:00+0900\",\"text\":\"금리\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"week\",\"timestamp\":\"2026-04-20T11:00:00+0900\",\"label\":\"mixed\"}".into(),
             "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"text\":\"달러\",\"linked_pulse_timestamp\":null}".into(),
         ];
         let dates = vec!["2026-04-20".into(), "2026-04-21".into()];
         let filtered = filter_events_by_dates(events, &dates, 10);
-        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered.len(), 3);
         assert!(filtered[0].contains("10:00:00"));
-        assert!(filtered[1].contains("11:00:00"));
+        assert!(filtered[1].contains("\"type\":\"week\""));
+        assert!(filtered[2].contains("11:00:00"));
+    }
+
+    #[test]
+    fn week_basis_names_current_calendar_window() {
+        let dates = vec!["2026-04-20".into(), "2026-04-21".into()];
+        let basis = week_basis(&dates);
+        assert!(basis[0].contains("current-week window 2026-04-20..2026-04-21"));
+        assert!(basis[1].contains("range=1mo interval=1d"));
+        assert!(basis[2].contains("current local calendar week"));
+    }
+
+    #[test]
+    fn first_close_for_dates_uses_matching_timestamp_date() {
+        let body =
+            "{\"timestamp\":[1776643200,1776729600],\"indicators\":{\"quote\":[{\"close\":[100.0,110.0]}]}}";
+        assert_eq!(
+            first_close_for_dates(body, &["2026-04-21".into()]).unwrap(),
+            110.0
+        );
     }
 
     #[test]
@@ -2971,7 +3072,7 @@ mod tests {
         let tensions = infer_week_tensions(&assets, &label);
         Weekly {
             timestamp: timestamp(),
-            basis: WEEK_QUOTE_BASIS.iter().map(|s| (*s).to_string()).collect(),
+            basis: week_basis(&["2026-04-20".into(), "2026-04-21".into()]),
             questions: infer_week_questions(&assets, &label, &tensions),
             label,
             assets,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--ago N]"
     );
 }
 
@@ -529,7 +529,20 @@ fn review(args: &[String]) -> Result<(), String> {
                 return Err("--date needs YYYY-MM-DD".into());
             };
             validate_review_date(raw)?;
+            if date.is_some() {
+                return Err("use only one review date selector".into());
+            }
             date = Some(raw.clone());
+            i += 1;
+        } else if args[i] == "--ago" || args[i] == "--days-ago" {
+            let Some(raw) = args.get(i + 1) else {
+                return Err(format!("{} needs a number of days", args[i]));
+            };
+            if date.is_some() {
+                return Err("use only one review date selector".into());
+            }
+            let days = parse_review_days_ago(raw)?;
+            date = Some(date_for_days_ago(days)?);
             i += 1;
         }
         i += 1;
@@ -541,6 +554,41 @@ fn review(args: &[String]) -> Result<(), String> {
     };
     println!("{rendered}");
     Ok(())
+}
+
+fn parse_review_days_ago(raw: &str) -> Result<u32, String> {
+    let days = raw
+        .parse::<u32>()
+        .map_err(|_| "--ago must be a non-negative whole number".to_string())?;
+    if days <= 3660 {
+        Ok(days)
+    } else {
+        Err("--ago must be 3660 days or less".into())
+    }
+}
+
+fn date_for_days_ago(days: u32) -> Result<String, String> {
+    if days == 0 {
+        return command_date(&["+%Y-%m-%d"])
+            .ok_or_else(|| "--ago needs the local `date` command".into());
+    }
+    let bsd_offset = format!("-v-{days}d");
+    if let Some(date) = command_date(&[&bsd_offset, "+%Y-%m-%d"]) {
+        return Ok(date);
+    }
+    let gnu_relative = format!("{days} days ago");
+    command_date(&["-d", &gnu_relative, "+%Y-%m-%d"])
+        .ok_or_else(|| "--ago needs BSD `date -v` or GNU `date -d` support".into())
+}
+
+fn command_date(args: &[&str]) -> Option<String> {
+    let output = Command::new("date").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let date = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    validate_review_date(&date).ok()?;
+    Some(date)
 }
 
 fn validate_review_date(date: &str) -> Result<(), String> {
@@ -2331,6 +2379,27 @@ mod tests {
         assert!(validate_review_date("2026-99-99").is_err());
         assert!(validate_review_date("yesterday").is_err());
         assert!(review(&["review".into(), "--date".into(), "bad".into()]).is_err());
+    }
+
+    #[test]
+    fn review_days_ago_validation_accepts_small_whole_numbers() {
+        assert_eq!(parse_review_days_ago("0").unwrap(), 0);
+        assert_eq!(parse_review_days_ago("5").unwrap(), 5);
+        assert!(parse_review_days_ago("-1").is_err());
+        assert!(parse_review_days_ago("1.5").is_err());
+        assert!(parse_review_days_ago("4000").is_err());
+    }
+
+    #[test]
+    fn review_rejects_multiple_date_selectors() {
+        assert!(review(&[
+            "review".into(),
+            "--date".into(),
+            "2026-04-21".into(),
+            "--ago".into(),
+            "1".into(),
+        ])
+        .is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1354,9 +1354,8 @@ fn infer_week_questions(assets: &[Asset], label: &str, tensions: &[String]) -> V
         push_tag(&mut tags, "oil");
     }
     let mut questions = validation_questions(&tags);
-    questions.push(
-        "By next Friday, what evidence would force you to rename this week’s market story?".into(),
-    );
+    questions
+        .push("By next Friday, what evidence would force you to rename this week’s story?".into());
     let mut unique = Vec::new();
     for question in questions {
         if !unique.contains(&question) {
@@ -1782,35 +1781,40 @@ fn push_tag(tags: &mut Vec<&'static str>, tag: &'static str) {
 fn validation_questions(tags: &[&str]) -> Vec<String> {
     let mut v = Vec::new();
     if tags.contains(&"rates") && tags.contains(&"semis") {
-        v.push("What evidence would prove growth leadership is absorbing rate pressure rather than just ignoring it for one session?".into());
-        v.push("What would falsify the rates/growth story: higher yields with semis still leading, or lower yields with weak breadth?".into());
-        v.push("What alternative fits the same tape better: earnings momentum, liquidity, positioning, or genuine easing expectations?".into());
-    } else if tags.contains(&"rates") {
+        v.push("What evidence shows growth leadership is absorbing rate pressure?".into());
+        v.push("What would falsify the rates/growth story: higher yields with weak breadth, or lower yields without growth leadership?".into());
         v.push(
-            "What would confirm this is easing expectations rather than growth-scare bond buying?"
+            "What alternative fits: earnings, liquidity, positioning, or genuine easing hopes?"
                 .into(),
         );
-        v.push("What would falsify the rates story if yields, dollar, and growth assets stop confirming each other?".into());
+    } else if tags.contains(&"rates") {
+        v.push("What confirms easing hopes rather than growth-scare bond buying?".into());
+        v.push(
+            "What falsifies the rates story if yields, dollar, and growth stop lining up?".into(),
+        );
     }
     if tags.contains(&"fx") && tags.contains(&"korea") {
-        v.push("What evidence would show FX is driving Korea risk rather than only translating a global move?".into());
-        v.push("What would falsify the FX-pressure read: KRW weakness without foreign selling, or exporters offsetting the drag?".into());
+        v.push("What evidence shows FX is driving Korea risk?".into());
+        v.push("What falsifies FX pressure: weak KRW without foreign selling, or exporters offsetting it?".into());
     } else if tags.contains(&"fx") {
-        v.push("What would prove dollar strength is a market-wide liquidity signal rather than a local currency move?".into());
+        v.push("What proves dollar strength is a market-wide liquidity signal?".into());
     }
     if tags.contains(&"oil") {
-        v.push("What evidence would show oil is changing inflation expectations instead of staying sector-specific?".into());
+        v.push("What evidence shows oil is changing inflation expectations?".into());
     }
     if tags.contains(&"event") {
-        v.push("What should move first if the IPO/listing/event explanation is actually driving the session?".into());
-        v.push("What would falsify the event story: broad assets moving before the event, or unrelated sectors leading?".into());
+        v.push("What should move first if the IPO/listing story is driving the session?".into());
+        v.push("What falsifies the event story: broad assets moving first, or unrelated sectors leading?".into());
     }
     if tags.contains(&"positioning") {
-        v.push("What would distinguish positioning or flow from a real change in growth, rates, or earnings expectations?".into());
+        v.push(
+            "What distinguishes positioning/flow from real changes in growth, rates, or earnings?"
+                .into(),
+        );
     }
     if v.is_empty() {
-        v.push("What evidence would confirm this interpretation, and what single observation would make it wrong?".into());
-        v.push("What alternative explanation could fit the same price action without forcing a one-cause story?".into());
+        v.push("What evidence confirms this view, and what observation makes it wrong?".into());
+        v.push("What alternative explains the same tape without a one-cause story?".into());
     }
     let mut unique = Vec::new();
     for question in v {
@@ -1848,26 +1852,26 @@ fn tags_from_summary(summary: &JournalSummary, limit: usize) -> Vec<&'static str
 fn recall_question(query: &str, filter: &str, tags: &[&str]) -> String {
     if tags.contains(&"rates") {
         return format!(
-            "In {filter}, were your old \"{query}\" notes assuming easing, growth scare, or rate pressure—and which current yield/dollar move would falsify that read?"
+            "In {filter}, did old \"{query}\" notes assume easing, growth scare, or rate pressure—and which yield/dollar move would falsify that read?"
         );
     }
     if tags.contains(&"fx") || tags.contains(&"korea") {
         return format!(
-            "In {filter}, did \"{query}\" mean global dollar pressure, Korea-specific stress, or sector rotation—and what current evidence would disprove it?"
+            "In {filter}, did \"{query}\" mean global dollar pressure, Korea stress, or sector rotation—and what evidence disproves it?"
         );
     }
     if tags.contains(&"event") || tags.contains(&"positioning") {
         return format!(
-            "In {filter}, was \"{query}\" an event/flow explanation or a durable market signal—and what would prove that old read was just timing noise?"
+            "In {filter}, was \"{query}\" event/flow or durable signal—and what proves the old read was timing noise?"
         );
     }
     if tags.contains(&"oil") {
         return format!(
-            "In {filter}, did \"{query}\" point to inflation pressure, demand, or sector rotation—and what would falsify that channel now?"
+            "In {filter}, did \"{query}\" mean inflation, demand, or sector rotation—and what falsifies that channel now?"
         );
     }
     format!(
-        "In {filter}, what changed since you last wrote about \"{query}\", and what evidence would falsify that old interpretation now?"
+        "In {filter}, what changed since \"{query}\", and what evidence falsifies that old interpretation now?"
     )
 }
 
@@ -1879,7 +1883,7 @@ fn review_drill(summary: &JournalSummary) -> String {
         tags.join(" + ")
     };
     format!(
-        "\nSuggested drill\n  For the next 3 notes, run a validation loop on {focus}:\n  1. claim: what market story am I telling?\n  2. confirming evidence: which asset/event should move next if I am right?\n  3. alternative: what else could explain the same tape?\n  4. falsifier: what observation would make me rename the view?"
+        "\nSuggested drill\n  For the next 3 notes, run a validation loop on {focus}:\n  1. claim: what story am I telling?\n  2. evidence: what should move next if I am right?\n  3. alternative: what else explains the same tape?\n  4. falsifier: what would make me rename the view?"
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ enum CommandKind {
     Regime,
     Think,
     Review,
+    Find,
     Help,
     Inquiry { text: String, no_save: bool },
     Research { text: String, no_save: bool },
@@ -232,6 +233,7 @@ fn run(args: Vec<String>) -> Result<(), String> {
         CommandKind::Regime => regime(&args),
         CommandKind::Think => think(&args),
         CommandKind::Review => review(&args),
+        CommandKind::Find => find(&args),
         CommandKind::Help => {
             print_help();
             Ok(())
@@ -250,6 +252,7 @@ fn parse_command(args: &[String]) -> Result<CommandKind, String> {
         Some("regime") => Ok(CommandKind::Regime),
         Some("think") => Ok(CommandKind::Think),
         Some("review") => Ok(CommandKind::Review),
+        Some("find") | Some("search") => Ok(CommandKind::Find),
         Some("help") | Some("--help") | Some("-h") => Ok(CommandKind::Help),
         Some("ask") => inquiry_command(&args[1..], "`mp ask` needs a question"),
         Some("research") => research_command(&args[1..], "`mp research` needs a question"),
@@ -293,7 +296,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp week [--no-save]\n  mp calendar\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp week [--no-save]\n  mp calendar\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]\n  mp find <query> [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]"
     );
 }
 
@@ -593,6 +596,79 @@ fn review(args: &[String]) -> Result<(), String> {
     };
     println!("{rendered}");
     Ok(())
+}
+
+fn find(args: &[String]) -> Result<(), String> {
+    let parsed = parse_find_args(args)?;
+    let rendered = render_find(parsed.limit, &parsed.query, parsed.filter.as_ref());
+    println!("{rendered}");
+    Ok(())
+}
+
+#[derive(Clone, Debug)]
+struct FindArgs {
+    query: String,
+    limit: usize,
+    filter: Option<ReviewFilter>,
+}
+
+fn parse_find_args(args: &[String]) -> Result<FindArgs, String> {
+    let mut limit = 20usize;
+    let mut filter: Option<ReviewFilter> = None;
+    let mut query_parts = Vec::new();
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--limit" {
+            let Some(raw) = args.get(i + 1) else {
+                return Err("--limit needs a number".into());
+            };
+            limit = raw
+                .parse()
+                .map_err(|_| "--limit must be a number".to_string())?;
+            i += 2;
+            continue;
+        }
+        if args[i] == "--date" {
+            let Some(raw) = args.get(i + 1) else {
+                return Err("--date needs YYYY-MM-DD".into());
+            };
+            validate_review_date(raw)?;
+            set_review_filter(&mut filter, ReviewFilter::Date(raw.clone()))?;
+            i += 2;
+            continue;
+        }
+        if matches!(args[i].as_str(), "--days" | "--ago" | "--days-ago") {
+            let Some(raw) = args.get(i + 1) else {
+                return Err(format!("{} needs a number of days", args[i]));
+            };
+            let days = parse_review_days_ago(raw)?;
+            set_review_filter(&mut filter, ReviewFilter::Date(date_for_days_ago(days)?))?;
+            i += 2;
+            continue;
+        }
+        if matches!(
+            args[i].as_str(),
+            "--today" | "--yesterday" | "--this-week" | "--last-week"
+        ) {
+            set_review_filter(&mut filter, review_filter_for_alias(&args[i])?)?;
+            i += 1;
+            continue;
+        }
+        if args[i].starts_with('-') {
+            return Err(format!("unknown find option '{}'", args[i]));
+        }
+        query_parts.push(args[i].clone());
+        i += 1;
+    }
+    let query = query_parts.join(" ").trim().to_string();
+    if query.is_empty() {
+        return Err("`mp find` needs a journal search query".into());
+    }
+    Ok(FindArgs {
+        query,
+        limit,
+        filter,
+    })
 }
 
 fn set_review_filter(filter: &mut Option<ReviewFilter>, next: ReviewFilter) -> Result<(), String> {
@@ -2230,6 +2306,14 @@ fn read_events_for_dates(limit: usize, dates: &[String]) -> Vec<String> {
     filter_events_by_dates(read_event_lines(&text), dates, limit)
 }
 
+fn read_events_for_filter(limit: usize, filter: Option<&ReviewFilter>) -> Vec<String> {
+    match filter {
+        Some(ReviewFilter::Date(date)) => read_events_for_date(limit, date),
+        Some(ReviewFilter::Dates { dates, .. }) => read_events_for_dates(limit, dates),
+        None => read_events(limit),
+    }
+}
+
 fn filter_events_by_date(events: Vec<String>, date: &str, limit: usize) -> Vec<String> {
     let lines = events
         .into_iter()
@@ -2333,6 +2417,37 @@ fn render_review_for_dates(limit: usize, label: &str, dates: &[String]) -> Strin
     render_review_for_dates_from_events(&events, &journal_path().display().to_string(), label)
 }
 
+fn render_find(limit: usize, query: &str, filter: Option<&ReviewFilter>) -> String {
+    let events = find_events(limit, query, filter);
+    render_find_from_events(
+        &events,
+        &journal_path().display().to_string(),
+        query,
+        filter_label(filter),
+    )
+}
+
+fn find_events(limit: usize, query: &str, filter: Option<&ReviewFilter>) -> Vec<String> {
+    let query = query.to_lowercase();
+    read_events_for_filter(usize::MAX, filter)
+        .into_iter()
+        .filter(|line| line.to_lowercase().contains(&query))
+        .rev()
+        .take(limit)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+fn filter_label(filter: Option<&ReviewFilter>) -> String {
+    match filter {
+        Some(ReviewFilter::Date(date)) => format!("date {date}"),
+        Some(ReviewFilter::Dates { label, .. }) => label.clone(),
+        None => "all journal entries".into(),
+    }
+}
+
 fn render_review_for_date_from_events(events: &[String], journal: &str, date: &str) -> String {
     if events.is_empty() {
         return format!(
@@ -2353,6 +2468,83 @@ fn render_review_for_dates_from_events(events: &[String], journal: &str, label: 
     let mut out = format!("Review period filter: {label}\n\n");
     out.push_str(&render_review_from_events(events, journal));
     out
+}
+
+fn render_find_from_events(
+    events: &[String],
+    journal: &str,
+    query: &str,
+    filter: String,
+) -> String {
+    if events.is_empty() {
+        return format!(
+            "No market-pulse journal entries matched \"{query}\".\n\nJournal: {journal}\nFilter: {filter}\nTry a simpler keyword, `mp calendar` for date windows, or record one with `mp ask`, `mp research`, or `mp think`."
+        );
+    }
+
+    let summary = summarize_events(events);
+    let mut out = format!(
+        "Market Pulse Find\n\nQuery: \"{query}\"\nFilter: {filter}\nJournal: {journal}\nEntries matched: {} · pulses {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nMatches\n",
+        events.len(),
+        summary.pulses,
+        summary.weeks,
+        summary.regimes,
+        summary.inquiries,
+        summary.research_inquiries,
+        summary.thoughts,
+        summary.feedback
+    );
+    for line in events.iter().rev().take(12) {
+        out.push_str(&format!("  - {}\n", event_recall_snippet(line, query)));
+    }
+
+    out.push_str("\nRecurring themes in matches\n");
+    let mut wrote_theme = false;
+    for (tag, count) in summary
+        .tag_counts
+        .into_iter()
+        .filter(|(_, count)| *count > 0)
+        .take(4)
+    {
+        wrote_theme = true;
+        out.push_str(&format!("  - {tag}: {count}\n"));
+    }
+    if !wrote_theme {
+        out.push_str("  - Not enough tagged matching entries yet\n");
+    }
+    out.push_str(&format!(
+        "\nNext recall question\n  What changed since you last wrote about \"{query}\", and what would falsify that old interpretation now?\n\nBoundary\n  `mp find` searches your local journal only. It is recall support for market literacy, not live research or trading advice."
+    ));
+    out
+}
+
+fn event_recall_snippet(line: &str, query: &str) -> String {
+    let timestamp = json_field(line, "timestamp").unwrap_or_else(|| "unknown-time".into());
+    let event_type = json_field(line, "type").unwrap_or_else(|| "entry".into());
+    let body = json_field(line, "text")
+        .or_else(|| json_field(line, "question"))
+        .or_else(|| json_field(line, "mood"))
+        .or_else(|| json_field(line, "concept"))
+        .or_else(|| json_field(line, "source_titles"))
+        .unwrap_or_else(|| compact_raw_event(line));
+    format!(
+        "{timestamp} · {event_type} · {}",
+        compact_snippet(&body, query)
+    )
+}
+
+fn compact_raw_event(line: &str) -> String {
+    compact_snippet(line, "")
+}
+
+fn compact_snippet(text: &str, _query: &str) -> String {
+    let cleaned = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let max_chars = 140usize;
+    if cleaned.chars().count() <= max_chars {
+        return cleaned;
+    }
+    let snippet = cleaned.chars().take(max_chars).collect::<String>();
+    format!("{snippet}...")
 }
 
 #[derive(Clone, Debug)]
@@ -2637,6 +2829,18 @@ mod tests {
         assert_eq!(
             parse_command(&["cal".into()]).unwrap(),
             CommandKind::Calendar
+        );
+    }
+
+    #[test]
+    fn routes_find_to_find_command() {
+        assert_eq!(
+            parse_command(&["find".into(), "금리".into()]).unwrap(),
+            CommandKind::Find
+        );
+        assert_eq!(
+            parse_command(&["search".into(), "달러".into()]).unwrap(),
+            CommandKind::Find
         );
     }
 
@@ -3010,6 +3214,89 @@ mod tests {
         assert!(out.contains("mp review --this-week"));
         assert!(out.contains("not fuzzy full-text search"));
         assert!(out.contains("not exchange-holiday calendars"));
+    }
+
+    #[test]
+    fn find_args_collect_query_and_period_selector() {
+        let args = vec![
+            "find".into(),
+            "금리".into(),
+            "성장주".into(),
+            "--this-week".into(),
+            "--limit".into(),
+            "3".into(),
+        ];
+        let parsed = parse_find_args(&args).unwrap();
+        assert_eq!(parsed.query, "금리 성장주");
+        assert_eq!(parsed.limit, 3);
+        match parsed.filter.unwrap() {
+            ReviewFilter::Dates { label, dates } => {
+                assert!(label.starts_with("this-week"));
+                assert!(!dates.is_empty());
+            }
+            ReviewFilter::Date(_) => panic!("expected period filter"),
+        }
+    }
+
+    #[test]
+    fn find_rejects_empty_query_and_multiple_selectors() {
+        assert!(parse_find_args(&["find".into(), "--this-week".into()]).is_err());
+        assert!(parse_find_args(&[
+            "find".into(),
+            "달러".into(),
+            "--today".into(),
+            "--last-week".into(),
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn find_events_filters_by_query_after_date_window() {
+        let events = vec![
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-19T09:00:00+0900\",\"text\":\"지난주 유가와 달러\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-20T10:00:00+0900\",\"text\":\"이번주 금리와 성장주\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"inquiry\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"question\":\"달러가 코스피에 부담?\",\"thesis_type\":\"dollar-liquidity transmission thesis\",\"concepts\":\"dollar liquidity\"}".into(),
+        ];
+        let dates = vec!["2026-04-20".into(), "2026-04-21".into()];
+        let filtered = filter_events_by_dates(events, &dates, 10);
+        let found = filtered
+            .into_iter()
+            .filter(|line| line.to_lowercase().contains("달러"))
+            .collect::<Vec<_>>();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].contains("코스피"));
+    }
+
+    #[test]
+    fn find_renders_recall_card_and_boundary() {
+        let events = vec![
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-20T10:00:00+0900\",\"text\":\"이번주 금리와 성장주 긴장\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"inquiry\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"question\":\"금리 하락이 성장주에 좋은 신호임?\",\"thesis_type\":\"rates / policy-expectation thesis\",\"concepts\":\"rates policy\"}".into(),
+        ];
+        let out = render_find_from_events(
+            &events,
+            "/tmp/journal.jsonl",
+            "금리",
+            "this-week 2026-04-20..2026-04-21".into(),
+        );
+        assert!(out.contains("Market Pulse Find"));
+        assert!(out.contains("Query: \"금리\""));
+        assert!(out.contains("Entries matched: 2"));
+        assert!(out.contains("Next recall question"));
+        assert!(out.contains("local journal only"));
+        assert!(out.contains("not live research or trading advice"));
+    }
+
+    #[test]
+    fn find_empty_result_points_to_calendar() {
+        let out = render_find_from_events(
+            &[],
+            "/tmp/journal.jsonl",
+            "반도체",
+            "last-week 2026-04-13..2026-04-19".into(),
+        );
+        assert!(out.contains("No market-pulse journal entries matched"));
+        assert!(out.contains("mp calendar"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD]"
     );
 }
 
@@ -514,6 +514,7 @@ fn research_source_from_json_line(line: &str) -> Option<ResearchSource> {
 
 fn review(args: &[String]) -> Result<(), String> {
     let mut limit = 80usize;
+    let mut date: Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         if args[i] == "--limit" {
@@ -523,11 +524,44 @@ fn review(args: &[String]) -> Result<(), String> {
                     .map_err(|_| "--limit must be a number".to_string())?;
             }
             i += 1;
+        } else if args[i] == "--date" {
+            let Some(raw) = args.get(i + 1) else {
+                return Err("--date needs YYYY-MM-DD".into());
+            };
+            validate_review_date(raw)?;
+            date = Some(raw.clone());
+            i += 1;
         }
         i += 1;
     }
-    println!("{}", render_review(limit));
+    let rendered = if let Some(date) = date {
+        render_review_for_date(limit, &date)
+    } else {
+        render_review(limit)
+    };
+    println!("{rendered}");
     Ok(())
+}
+
+fn validate_review_date(date: &str) -> Result<(), String> {
+    let bytes = date.as_bytes();
+    let shape_valid = bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(i, b)| i == 4 || i == 7 || b.is_ascii_digit());
+    if !shape_valid {
+        return Err("--date must use YYYY-MM-DD".into());
+    }
+    let month = date[5..7].parse::<u32>().unwrap_or(0);
+    let day = date[8..10].parse::<u32>().unwrap_or(0);
+    if (1..=12).contains(&month) && (1..=31).contains(&day) {
+        Ok(())
+    } else {
+        Err("--date must be a valid YYYY-MM-DD date".into())
+    }
 }
 
 fn build_pulse() -> Pulse {
@@ -1641,15 +1675,40 @@ fn read_events(limit: usize) -> Vec<String> {
     let Ok(text) = fs::read_to_string(journal_path()) else {
         return Vec::new();
     };
-    let mut lines = text
-        .lines()
+    limit_events(read_event_lines(&text), limit)
+}
+
+fn read_event_lines(text: &str) -> Vec<String> {
+    text.lines()
         .filter(|l| !l.trim().is_empty())
         .map(str::to_string)
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+fn limit_events(mut lines: Vec<String>, limit: usize) -> Vec<String> {
     if lines.len() > limit {
         lines = lines.split_off(lines.len() - limit);
     }
     lines
+}
+
+fn read_events_for_date(limit: usize, date: &str) -> Vec<String> {
+    let Ok(text) = fs::read_to_string(journal_path()) else {
+        return Vec::new();
+    };
+    filter_events_by_date(read_event_lines(&text), date, limit)
+}
+
+fn filter_events_by_date(events: Vec<String>, date: &str, limit: usize) -> Vec<String> {
+    let lines = events
+        .into_iter()
+        .filter(|l| event_matches_date(l, date))
+        .collect::<Vec<_>>();
+    limit_events(lines, limit)
+}
+
+fn event_matches_date(line: &str, date: &str) -> bool {
+    json_field(line, "timestamp").is_some_and(|ts| ts.starts_with(date))
 }
 
 fn latest_pulse_timestamp() -> Option<String> {
@@ -1707,6 +1766,22 @@ fn parse_json_string(text_after_opening_quote: &str) -> Option<String> {
 fn render_review(limit: usize) -> String {
     let events = read_events(limit);
     render_review_from_events(&events, &journal_path().display().to_string())
+}
+
+fn render_review_for_date(limit: usize, date: &str) -> String {
+    let events = read_events_for_date(limit, date);
+    render_review_for_date_from_events(&events, &journal_path().display().to_string(), date)
+}
+
+fn render_review_for_date_from_events(events: &[String], journal: &str, date: &str) -> String {
+    if events.is_empty() {
+        return format!(
+            "No market-pulse journal entries found for {date}.\n\nJournal: {journal}\nTry `mp review --limit N` to inspect recent entries, or record one with `mp now`, `mp regime`, `mp ask`, or `mp think`."
+        );
+    }
+    let mut out = format!("Review date filter: {date}\n\n");
+    out.push_str(&render_review_from_events(events, journal));
+    out
 }
 
 fn render_review_from_events(events: &[String], journal: &str) -> String {
@@ -2210,6 +2285,52 @@ mod tests {
         assert!(out.contains("Question / thesis habits"));
         assert!(out.contains("event"));
         assert!(out.contains("rates"));
+    }
+
+    #[test]
+    fn review_date_filter_keeps_only_matching_timestamp_date() {
+        let events = vec![
+            "{\"type\":\"inquiry\",\"timestamp\":\"2026-04-20T09:00:00+0900\",\"question\":\"달러가 코스피에 부담?\",\"thesis_type\":\"dollar-liquidity transmission thesis\",\"concepts\":\"dollar liquidity\"}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T10:00:00+0900\",\"text\":\"금리가 내려가는데 성장주가 버틴다\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"research_inquiry\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"question\":\"대형 IPO가 시장에 영향?\",\"provider\":\"noop\",\"source_count\":0,\"thesis_type\":\"event-driven / supply-calendar thesis\",\"concepts\":\"event-driven supply/attention\"}".into(),
+        ];
+        let filtered = filter_events_by_date(events, "2026-04-21", 80);
+        assert_eq!(filtered.len(), 2);
+        let out = render_review_for_date_from_events(&filtered, "/tmp/journal.jsonl", "2026-04-21");
+        assert!(out.contains("Review date filter: 2026-04-21"));
+        assert!(out.contains("Entries scanned: 2"));
+        assert!(out.contains("rates"));
+        assert!(out.contains("event"));
+        assert!(!out.contains("dollar-liquidity"));
+    }
+
+    #[test]
+    fn review_date_filter_applies_limit_after_date_match() {
+        let events = vec![
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T09:00:00+0900\",\"text\":\"금리\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T10:00:00+0900\",\"text\":\"달러\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"text\":\"유가\",\"linked_pulse_timestamp\":null}".into(),
+        ];
+        let filtered = filter_events_by_date(events, "2026-04-21", 2);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered[0].contains("10:00:00"));
+        assert!(filtered[1].contains("11:00:00"));
+    }
+
+    #[test]
+    fn review_date_filter_has_empty_date_message() {
+        let out = render_review_for_date_from_events(&[], "/tmp/journal.jsonl", "2026-04-19");
+        assert!(out.contains("No market-pulse journal entries found for 2026-04-19"));
+        assert!(out.contains("mp review --limit N"));
+    }
+
+    #[test]
+    fn review_date_validation_rejects_non_iso_date() {
+        assert!(validate_review_date("2026-04-21").is_ok());
+        assert!(validate_review_date("20260421").is_err());
+        assert!(validate_review_date("2026-99-99").is_err());
+        assert!(validate_review_date("yesterday").is_err());
+        assert!(review(&["review".into(), "--date".into(), "bad".into()]).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--ago N]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N]"
     );
 }
 
@@ -534,7 +534,7 @@ fn review(args: &[String]) -> Result<(), String> {
             }
             date = Some(raw.clone());
             i += 1;
-        } else if args[i] == "--ago" || args[i] == "--days-ago" {
+        } else if matches!(args[i].as_str(), "--days" | "--ago" | "--days-ago") {
             let Some(raw) = args.get(i + 1) else {
                 return Err(format!("{} needs a number of days", args[i]));
             };
@@ -559,18 +559,18 @@ fn review(args: &[String]) -> Result<(), String> {
 fn parse_review_days_ago(raw: &str) -> Result<u32, String> {
     let days = raw
         .parse::<u32>()
-        .map_err(|_| "--ago must be a non-negative whole number".to_string())?;
+        .map_err(|_| "--days must be a non-negative whole number".to_string())?;
     if days <= 3660 {
         Ok(days)
     } else {
-        Err("--ago must be 3660 days or less".into())
+        Err("--days must be 3660 days or less".into())
     }
 }
 
 fn date_for_days_ago(days: u32) -> Result<String, String> {
     if days == 0 {
         return command_date(&["+%Y-%m-%d"])
-            .ok_or_else(|| "--ago needs the local `date` command".into());
+            .ok_or_else(|| "--days needs the local `date` command".into());
     }
     let bsd_offset = format!("-v-{days}d");
     if let Some(date) = command_date(&[&bsd_offset, "+%Y-%m-%d"]) {
@@ -578,7 +578,7 @@ fn date_for_days_ago(days: u32) -> Result<String, String> {
     }
     let gnu_relative = format!("{days} days ago");
     command_date(&["-d", &gnu_relative, "+%Y-%m-%d"])
-        .ok_or_else(|| "--ago needs BSD `date -v` or GNU `date -d` support".into())
+        .ok_or_else(|| "--days needs BSD `date -v` or GNU `date -d` support".into())
 }
 
 fn command_date(args: &[&str]) -> Option<String> {
@@ -2396,7 +2396,7 @@ mod tests {
             "review".into(),
             "--date".into(),
             "2026-04-21".into(),
-            "--ago".into(),
+            "--days".into(),
             "1".into(),
         ])
         .is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,19 @@ struct Pulse {
 }
 
 #[derive(Clone, Debug)]
+struct Regime {
+    timestamp: String,
+    basis: Vec<String>,
+    label: String,
+    assets: Vec<Asset>,
+    drivers: Vec<String>,
+    tensions: Vec<String>,
+    checks: Vec<String>,
+    question: String,
+    notes: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
 struct Inquiry {
     timestamp: String,
     question: String,
@@ -158,6 +171,7 @@ struct Feedback {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum CommandKind {
     Now,
+    Regime,
     Think,
     Review,
     Help,
@@ -169,6 +183,12 @@ const PULSE_QUOTE_BASIS: &[&str] = &[
     "time: local machine timestamp and session label",
     "change: latest Yahoo regularMarketPrice vs chartPreviousClose, usually the prior regular-session close",
     "window: Yahoo chart range=5d interval=1d; this is a session/daily pulse, not a weekly return",
+];
+
+const REGIME_QUOTE_BASIS: &[&str] = &[
+    "time: local machine timestamp; regime is broader than today's pulse",
+    "change: latest Yahoo regularMarketPrice vs first available close in the chart window",
+    "window: Yahoo chart range=3mo interval=1wk; this is a 1-3 month regime read, not a trading signal",
 ];
 
 const SYMBOLS: &[(&str, &str, &str)] = &[
@@ -193,6 +213,7 @@ pub fn main_entry() {
 fn run(args: Vec<String>) -> Result<(), String> {
     match parse_command(&args)? {
         CommandKind::Now => now(&args),
+        CommandKind::Regime => regime(&args),
         CommandKind::Think => think(&args),
         CommandKind::Review => review(&args),
         CommandKind::Help => {
@@ -208,6 +229,7 @@ fn parse_command(args: &[String]) -> Result<CommandKind, String> {
     match args.first().map(String::as_str) {
         None => Ok(CommandKind::Now),
         Some("now") => Ok(CommandKind::Now),
+        Some("regime") => Ok(CommandKind::Regime),
         Some("think") => Ok(CommandKind::Think),
         Some("review") => Ok(CommandKind::Review),
         Some("help") | Some("--help") | Some("-h") => Ok(CommandKind::Help),
@@ -253,7 +275,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N]"
     );
 }
 
@@ -265,6 +287,16 @@ fn now(args: &[String]) -> Result<(), String> {
         append_event(&pulse_json(&pulse))?;
     }
     println!("{}", render_pulse(&pulse, compact));
+    Ok(())
+}
+
+fn regime(args: &[String]) -> Result<(), String> {
+    let no_save = args.iter().any(|a| a == "--no-save");
+    let regime = build_regime();
+    if !no_save {
+        append_event(&regime_json(&regime))?;
+    }
+    println!("{}", render_regime(&regime));
     Ok(())
 }
 
@@ -548,14 +580,87 @@ fn build_pulse() -> Pulse {
     }
 }
 
+fn build_regime() -> Regime {
+    let mut assets = Vec::new();
+    let mut failures = 0;
+    for (symbol, label, unit) in SYMBOLS {
+        match fetch_asset_window(symbol, label, unit, "3mo", "1wk", WindowChange::FirstClose) {
+            Ok(asset) => assets.push(asset),
+            Err(_) => {
+                failures += 1;
+                assets.push(Asset {
+                    symbol,
+                    label,
+                    unit,
+                    value: None,
+                    change: None,
+                    note: Some("regime data unavailable".into()),
+                });
+            }
+        }
+    }
+    let mut notes = vec![
+        "market regime uses Yahoo Finance chart endpoint via curl".to_string(),
+        "interpret as learning scaffold, not investment advice or a trading signal".to_string(),
+    ];
+    if failures > 0 {
+        notes.push(format!(
+            "{failures} quote(s) unavailable; regime read is partial"
+        ));
+    }
+    let avg_equity = avg_change(&assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
+    let label = infer_regime_label(
+        avg_equity,
+        change_for(&assets, "DX-Y.NYB"),
+        change_for(&assets, "^TNX"),
+        change_for(&assets, "CL=F"),
+        change_for(&assets, "BTC-USD"),
+    );
+    let drivers = infer_regime_drivers(&assets);
+    let tensions = infer_regime_tensions(&assets, &label);
+    let checks = infer_regime_checks(&assets, &label);
+    let question = infer_regime_question(&label, &tensions);
+    Regime {
+        timestamp: timestamp(),
+        basis: REGIME_QUOTE_BASIS
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect(),
+        label,
+        assets,
+        drivers,
+        tensions,
+        checks,
+        question,
+        notes,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum WindowChange {
+    PreviousClose,
+    FirstClose,
+}
+
 fn fetch_asset(
     symbol: &'static str,
     label: &'static str,
     unit: &'static str,
 ) -> Result<Asset, String> {
+    fetch_asset_window(symbol, label, unit, "5d", "1d", WindowChange::PreviousClose)
+}
+
+fn fetch_asset_window(
+    symbol: &'static str,
+    label: &'static str,
+    unit: &'static str,
+    range: &str,
+    interval: &str,
+    change_from: WindowChange,
+) -> Result<Asset, String> {
     let url = format!(
-        "https://query1.finance.yahoo.com/v8/finance/chart/{}?range=5d&interval=1d",
-        encode_symbol(symbol)
+        "https://query1.finance.yahoo.com/v8/finance/chart/{}?range={range}&interval={interval}",
+        encode_symbol(symbol),
     );
     let output = Command::new("curl")
         .args([
@@ -573,12 +678,13 @@ fn fetch_asset(
         return Err("curl failed".into());
     }
     let body = String::from_utf8_lossy(&output.stdout);
-    let value = number_after(&body, "\"regularMarketPrice\":")
-        .or_else(|| close_values(&body).last().copied());
-    let previous = number_after(&body, "\"chartPreviousClose\":").or_else(|| {
-        let vals = close_values(&body);
-        vals.get(vals.len().saturating_sub(2)).copied()
-    });
+    let closes = close_values(&body);
+    let value = number_after(&body, "\"regularMarketPrice\":").or_else(|| closes.last().copied());
+    let previous = match change_from {
+        WindowChange::PreviousClose => number_after(&body, "\"chartPreviousClose\":")
+            .or_else(|| closes.get(closes.len().saturating_sub(2)).copied()),
+        WindowChange::FirstClose => closes.first().copied(),
+    };
     let change = match (value, previous) {
         (Some(v), Some(p)) if p != 0.0 => Some(((v - p) / p) * 100.0),
         _ => None,
@@ -747,6 +853,146 @@ fn infer_concept(tensions: &[String], drivers: &[String]) -> String {
         "inflation impulse"
     } else {
         "risk-on / risk-off"
+    }
+    .into()
+}
+
+fn infer_regime_label(
+    avg_equity: f64,
+    usd: Option<f64>,
+    rates: Option<f64>,
+    oil: Option<f64>,
+    btc: Option<f64>,
+) -> String {
+    let macro_pressure = usd.is_some_and(|v| v > 1.0)
+        || rates.is_some_and(|v| v > 3.0)
+        || oil.is_some_and(|v| v > 8.0);
+    let high_beta = btc.is_some_and(|v| v > 10.0);
+    if avg_equity > 5.0 && !macro_pressure {
+        "risk-on / growth-led regime"
+    } else if avg_equity > 2.0 && macro_pressure {
+        "equity resilience under macro pressure"
+    } else if avg_equity < -3.0 && macro_pressure {
+        "macro-pressure / de-risking regime"
+    } else if avg_equity < -3.0 {
+        "risk-off / earnings-growth doubt"
+    } else if high_beta && avg_equity >= 0.0 {
+        "liquidity-sensitive high-beta regime"
+    } else {
+        "mixed / transition regime"
+    }
+    .into()
+}
+
+fn infer_regime_drivers(assets: &[Asset]) -> Vec<String> {
+    let mut drivers = Vec::new();
+    if change_for(assets, "^IXIC").is_some_and(|v| v > 5.0) {
+        drivers.push("Nasdaq strength suggests growth/AI leadership is part of the regime".into());
+    }
+    if avg_change(assets, &["^GSPC", "^IXIC", "^KS11"]).is_some_and(|v| v > 4.0) {
+        drivers.push("Equity indexes are broadly higher over the regime window".into());
+    }
+    if change_for(assets, "DX-Y.NYB").is_some_and(|v| v > 1.0)
+        || change_for(assets, "KRW=X").is_some_and(|v| v > 1.0)
+    {
+        drivers.push("Dollar/FX strength is a macro pressure channel to keep checking".into());
+    }
+    if change_for(assets, "^TNX").is_some_and(|v| v > 3.0) {
+        drivers.push(
+            "US 10Y yields are higher over the window, so discount-rate pressure matters".into(),
+        );
+    }
+    if change_for(assets, "CL=F").is_some_and(|v| v > 8.0) {
+        drivers.push("Oil is higher enough to keep inflation and margin narratives alive".into());
+    }
+    if change_for(assets, "GC=F").is_some_and(|v| v > 5.0) {
+        drivers.push(
+            "Gold strength points to hedge demand, liquidity concern, or real-rate debate".into(),
+        );
+    }
+    if change_for(assets, "BTC-USD").is_some_and(|v| v > 10.0) {
+        drivers.push("BTC strength suggests high-beta liquidity appetite is active".into());
+    }
+    if drivers.is_empty() {
+        drivers
+            .push("No single 1-3 month driver dominates; treat the regime as transitionary".into());
+        drivers
+            .push("Compare equities, yields, dollar, and oil before trusting one headline".into());
+    }
+    drivers.truncate(5);
+    drivers
+}
+
+fn infer_regime_tensions(assets: &[Asset], label: &str) -> Vec<String> {
+    let mut tensions = Vec::new();
+    let avg_equity = avg_change(assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
+    if avg_equity > 2.0
+        && (change_for(assets, "^TNX").is_some_and(|v| v > 3.0)
+            || change_for(assets, "DX-Y.NYB").is_some_and(|v| v > 1.0))
+    {
+        tensions.push("equity strength vs tighter financial-condition signals".into());
+    }
+    if change_for(assets, "^IXIC").unwrap_or(0.0) - change_for(assets, "^KS11").unwrap_or(0.0) > 5.0
+    {
+        tensions.push("US growth leadership vs Korea/EM follow-through".into());
+    }
+    if change_for(assets, "CL=F").is_some_and(|v| v > 8.0) && avg_equity > 0.0 {
+        tensions.push("risk appetite vs oil/inflation impulse".into());
+    }
+    if change_for(assets, "GC=F").is_some_and(|v| v > 5.0) && avg_equity > 0.0 {
+        tensions.push("risk-on equities vs defensive/hedge demand in gold".into());
+    }
+    if label.contains("transition") {
+        tensions.push("short-term pulse may disagree with the 1-3 month backdrop".into());
+    }
+    if tensions.is_empty() {
+        tensions.push("headline trend vs cross-asset confirmation".into());
+    }
+    tensions.truncate(4);
+    tensions
+}
+
+fn infer_regime_checks(assets: &[Asset], label: &str) -> Vec<String> {
+    let mut checks = Vec::new();
+    if label.contains("resilience") || label.contains("pressure") {
+        checks.push(
+            "Check whether yields and dollar are rising for the same reason or different reasons"
+                .into(),
+        );
+    }
+    if change_for(assets, "^IXIC").is_some() && change_for(assets, "^GSPC").is_some() {
+        checks.push(
+            "Compare Nasdaq vs S&P 500 to separate growth leadership from broad risk appetite"
+                .into(),
+        );
+    }
+    if change_for(assets, "^KS11").is_some() {
+        checks.push(
+            "Check whether Korea/KOSPI confirms the US story or lags because of FX/EM pressure"
+                .into(),
+        );
+    }
+    if change_for(assets, "CL=F").is_some() {
+        checks.push(
+            "Watch oil: if it keeps rising, inflation narratives can change the regime label"
+                .into(),
+        );
+    }
+    checks.push("Ask what evidence would force you to rename this regime next week".into());
+    checks.truncate(5);
+    checks
+}
+
+fn infer_regime_question(label: &str, tensions: &[String]) -> String {
+    let text = format!("{label} {}", tensions.join(" ")).to_lowercase();
+    if text.contains("macro pressure") || text.contains("financial-condition") {
+        "Is equity strength absorbing macro pressure, or has the market not priced it yet?"
+    } else if text.contains("growth") || text.contains("nasdaq") {
+        "Is this regime broad risk-on, or mostly growth/AI leadership?"
+    } else if text.contains("transition") {
+        "What single cross-asset signal would prove the regime is changing?"
+    } else {
+        "Which asset best confirms the 1-3 month regime, and which asset disagrees?"
     }
     .into()
 }
@@ -1150,6 +1396,68 @@ fn render_pulse(p: &Pulse, compact: bool) -> String {
     out
 }
 
+fn render_regime(r: &Regime) -> String {
+    let mut out = format!(
+        "Market Regime · {}\n\nRegime\n  {}\n\nBasis\n",
+        r.timestamp, r.label
+    );
+    for b in &r.basis {
+        out.push_str(&format!("  - {b}\n"));
+    }
+    out.push_str("\n1-3M Asset Map\n");
+    for a in &r.assets {
+        let value = a
+            .value
+            .map(|v| {
+                format!(
+                    "{v:.2}{}",
+                    if a.unit.is_empty() {
+                        "".to_string()
+                    } else {
+                        format!(" {}", a.unit)
+                    }
+                )
+            })
+            .unwrap_or_else(|| "n/a".into());
+        let change = a
+            .change
+            .map(|c| format!("{:+.2}%", c))
+            .unwrap_or_else(|| "n/a".into());
+        let note = a
+            .note
+            .as_ref()
+            .map(|n| format!(" · {n}"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "  - {}: {} ({}){}\n",
+            a.label, value, change, note
+        ));
+    }
+    out.push_str("\nRegime drivers\n");
+    for (i, d) in r.drivers.iter().enumerate() {
+        out.push_str(&format!("  {}. {}\n", i + 1, d));
+    }
+    out.push_str("\nRegime tensions\n");
+    for t in &r.tensions {
+        out.push_str(&format!("  - {t}\n"));
+    }
+    out.push_str("\nChecks for next session/week\n");
+    for c in &r.checks {
+        out.push_str(&format!("  - {c}\n"));
+    }
+    out.push_str(&format!(
+        "\nNext better regime question\n  {}\n\nBoundary\n  Market literacy only; not investment advice, buy/sell guidance, price targets, stop-loss, or portfolio instructions.\n",
+        r.question
+    ));
+    if !r.notes.is_empty() {
+        out.push_str("\nSource notes\n");
+        for n in &r.notes {
+            out.push_str(&format!("  - {n}\n"));
+        }
+    }
+    out
+}
+
 fn question_seeds_for(p: &Pulse) -> Vec<String> {
     let text = format!(
         "{} {} {}",
@@ -1413,6 +1721,10 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
         .iter()
         .filter(|l| l.contains("\"type\":\"thought\""))
         .count();
+    let regimes = events
+        .iter()
+        .filter(|l| l.contains("\"type\":\"regime\""))
+        .count();
     let inquiries = events
         .iter()
         .filter(|l| l.contains("\"type\":\"inquiry\""))
@@ -1457,7 +1769,7 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
     counts.sort_by(|a, b| b.1.cmp(&a.1));
     thesis_types.sort();
     thesis_types.dedup();
-    let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), pulses, inquiries, research_inquiries, thoughts, feedback);
+    let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), pulses, regimes, inquiries, research_inquiries, thoughts, feedback);
     let mut wrote = false;
     for (tag, count) in counts.into_iter().filter(|(_, c)| *c > 0).take(6) {
         wrote = true;
@@ -1487,6 +1799,16 @@ fn pulse_json(p: &Pulse) -> String {
         esc(&p.mood),
         esc(&p.question),
         esc(&p.concept)
+    )
+}
+
+fn regime_json(r: &Regime) -> String {
+    format!(
+        "{{\"type\":\"regime\",\"timestamp\":\"{}\",\"basis\":\"{}\",\"label\":\"{}\",\"question\":\"{}\"}}",
+        esc(&r.timestamp),
+        esc(&r.basis.join(" | ")),
+        esc(&r.label),
+        esc(&r.question)
     )
 }
 
@@ -1606,6 +1928,14 @@ mod tests {
         );
         assert!(parse_command(&["ask".into()]).is_err());
         assert!(parse_command(&["--bad".into()]).is_err());
+    }
+
+    #[test]
+    fn routes_regime_to_regime_command() {
+        assert_eq!(
+            parse_command(&["regime".into(), "--no-save".into()]).unwrap(),
+            CommandKind::Regime
+        );
     }
 
     #[test]
@@ -1919,6 +2249,50 @@ mod tests {
         assert!(rendered.contains("not a weekly return"));
     }
 
+    #[test]
+    fn regime_renders_timeframe_basis_and_boundaries() {
+        let regime = compose_test_regime(vec![
+            Asset {
+                symbol: "^IXIC",
+                label: "Nasdaq",
+                unit: "",
+                value: Some(100.0),
+                change: Some(8.0),
+                note: None,
+            },
+            Asset {
+                symbol: "^GSPC",
+                label: "S&P 500",
+                unit: "",
+                value: Some(100.0),
+                change: Some(4.0),
+                note: None,
+            },
+            Asset {
+                symbol: "^TNX",
+                label: "US 10Y",
+                unit: "%",
+                value: Some(4.8),
+                change: Some(4.0),
+                note: None,
+            },
+            Asset {
+                symbol: "DX-Y.NYB",
+                label: "DXY",
+                unit: "",
+                value: Some(105.0),
+                change: Some(1.2),
+                note: None,
+            },
+        ]);
+        assert!(regime.label.contains("resilience") || regime.label.contains("risk-on"));
+        let rendered = render_regime(&regime);
+        assert!(rendered.contains("Market Regime"));
+        assert!(rendered.contains("1-3 month regime read"));
+        assert!(rendered.contains("Next better regime question"));
+        assert!(rendered.contains("not investment advice"));
+    }
+
     fn compose_test_pulse(assets: Vec<Asset>) -> Pulse {
         let avg_equity = avg_change(&assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
         let mood = infer_mood(
@@ -1936,6 +2310,33 @@ mod tests {
             question: infer_question(&tensions, &mood),
             concept: infer_concept(&tensions, &drivers),
             mood,
+            assets,
+            drivers,
+            tensions,
+            notes: vec![],
+        }
+    }
+
+    fn compose_test_regime(assets: Vec<Asset>) -> Regime {
+        let avg_equity = avg_change(&assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
+        let label = infer_regime_label(
+            avg_equity,
+            change_for(&assets, "DX-Y.NYB"),
+            change_for(&assets, "^TNX"),
+            change_for(&assets, "CL=F"),
+            change_for(&assets, "BTC-USD"),
+        );
+        let drivers = infer_regime_drivers(&assets);
+        let tensions = infer_regime_tensions(&assets, &label);
+        Regime {
+            timestamp: timestamp(),
+            basis: REGIME_QUOTE_BASIS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+            question: infer_regime_question(&label, &tensions),
+            checks: infer_regime_checks(&assets, &label),
+            label,
             assets,
             drivers,
             tensions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ struct Feedback {
 enum CommandKind {
     Now,
     Week,
+    Calendar,
     Regime,
     Think,
     Review,
@@ -227,6 +228,7 @@ fn run(args: Vec<String>) -> Result<(), String> {
     match parse_command(&args)? {
         CommandKind::Now => now(&args),
         CommandKind::Week => week(&args),
+        CommandKind::Calendar => calendar(&args),
         CommandKind::Regime => regime(&args),
         CommandKind::Think => think(&args),
         CommandKind::Review => review(&args),
@@ -244,6 +246,7 @@ fn parse_command(args: &[String]) -> Result<CommandKind, String> {
         None => Ok(CommandKind::Now),
         Some("now") => Ok(CommandKind::Now),
         Some("week") | Some("weekly") => Ok(CommandKind::Week),
+        Some("calendar") | Some("cal") => Ok(CommandKind::Calendar),
         Some("regime") => Ok(CommandKind::Regime),
         Some("think") => Ok(CommandKind::Think),
         Some("review") => Ok(CommandKind::Review),
@@ -290,7 +293,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp week [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp week [--no-save]\n  mp calendar\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]"
     );
 }
 
@@ -323,6 +326,11 @@ fn regime(args: &[String]) -> Result<(), String> {
         append_event(&regime_json(&regime))?;
     }
     println!("{}", render_regime(&regime));
+    Ok(())
+}
+
+fn calendar(_args: &[String]) -> Result<(), String> {
+    println!("{}", render_calendar());
     Ok(())
 }
 
@@ -538,9 +546,15 @@ fn research_source_from_json_line(line: &str) -> Option<ResearchSource> {
     })
 }
 
+#[derive(Clone, Debug)]
+enum ReviewFilter {
+    Date(String),
+    Dates { label: String, dates: Vec<String> },
+}
+
 fn review(args: &[String]) -> Result<(), String> {
     let mut limit = 80usize;
-    let mut date: Option<String> = None;
+    let mut filter: Option<ReviewFilter> = None;
     let mut i = 1;
     while i < args.len() {
         if args[i] == "--limit" {
@@ -555,31 +569,60 @@ fn review(args: &[String]) -> Result<(), String> {
                 return Err("--date needs YYYY-MM-DD".into());
             };
             validate_review_date(raw)?;
-            if date.is_some() {
-                return Err("use only one review date selector".into());
-            }
-            date = Some(raw.clone());
+            set_review_filter(&mut filter, ReviewFilter::Date(raw.clone()))?;
             i += 1;
         } else if matches!(args[i].as_str(), "--days" | "--ago" | "--days-ago") {
             let Some(raw) = args.get(i + 1) else {
                 return Err(format!("{} needs a number of days", args[i]));
             };
-            if date.is_some() {
-                return Err("use only one review date selector".into());
-            }
             let days = parse_review_days_ago(raw)?;
-            date = Some(date_for_days_ago(days)?);
+            set_review_filter(&mut filter, ReviewFilter::Date(date_for_days_ago(days)?))?;
             i += 1;
+        } else if matches!(
+            args[i].as_str(),
+            "--today" | "--yesterday" | "--this-week" | "--last-week"
+        ) {
+            set_review_filter(&mut filter, review_filter_for_alias(&args[i])?)?;
         }
         i += 1;
     }
-    let rendered = if let Some(date) = date {
-        render_review_for_date(limit, &date)
+    let rendered = if let Some(filter) = filter {
+        render_review_for_filter(limit, &filter)
     } else {
         render_review(limit)
     };
     println!("{rendered}");
     Ok(())
+}
+
+fn set_review_filter(filter: &mut Option<ReviewFilter>, next: ReviewFilter) -> Result<(), String> {
+    if filter.is_some() {
+        return Err("use only one review date selector".into());
+    }
+    *filter = Some(next);
+    Ok(())
+}
+
+fn review_filter_for_alias(alias: &str) -> Result<ReviewFilter, String> {
+    match alias {
+        "--today" => Ok(ReviewFilter::Date(date_for_days_ago(0)?)),
+        "--yesterday" => Ok(ReviewFilter::Date(date_for_days_ago(1)?)),
+        "--this-week" => {
+            let dates = current_week_date_prefixes();
+            Ok(ReviewFilter::Dates {
+                label: format!("this-week {}", week_window_label(&dates)),
+                dates,
+            })
+        }
+        "--last-week" => {
+            let dates = last_week_date_prefixes();
+            Ok(ReviewFilter::Dates {
+                label: format!("last-week {}", week_window_label(&dates)),
+                dates,
+            })
+        }
+        _ => Err(format!("unknown review period alias '{alias}'")),
+    }
 }
 
 fn parse_review_days_ago(raw: &str) -> Result<u32, String> {
@@ -612,6 +655,21 @@ fn current_week_date_prefixes() -> Vec<String> {
         return date_prefixes_for_days(7);
     };
     let mut dates = (0..weekday)
+        .filter_map(|days_ago| date_for_days_ago(days_ago).ok())
+        .collect::<Vec<_>>();
+    dates.reverse();
+    dates
+}
+
+fn last_week_date_prefixes() -> Vec<String> {
+    let Some(weekday) = iso_weekday() else {
+        let mut dates = (7..14)
+            .filter_map(|days_ago| date_for_days_ago(days_ago).ok())
+            .collect::<Vec<_>>();
+        dates.reverse();
+        return dates;
+    };
+    let mut dates = (weekday..weekday + 7)
         .filter_map(|days_ago| date_for_days_ago(days_ago).ok())
         .collect::<Vec<_>>();
     dates.reverse();
@@ -2073,6 +2131,37 @@ fn render_feedback(f: &Feedback) -> String {
     out
 }
 
+fn render_calendar() -> String {
+    let today = date_for_days_ago(0).unwrap_or_else(|_| "unavailable".into());
+    let yesterday = date_for_days_ago(1).unwrap_or_else(|_| "unavailable".into());
+    let this_week = current_week_date_prefixes();
+    let last_week = last_week_date_prefixes();
+    let mut out = format!(
+        "Market Pulse Calendar · {}\n\nLocal date windows\n",
+        timestamp()
+    );
+    out.push_str(&format!("  - today: {today}\n"));
+    out.push_str(&format!("  - yesterday: {yesterday}\n"));
+    out.push_str(&format!(
+        "  - this-week: {}\n",
+        week_window_label(&this_week)
+    ));
+    out.push_str(&format!(
+        "  - last-week: {}\n",
+        week_window_label(&last_week)
+    ));
+    out.push_str(
+        "\nReview shortcuts\n  - mp review --today\n  - mp review --yesterday\n  - mp review --this-week\n  - mp review --last-week\n",
+    );
+    out.push_str(
+        "\nHow market-pulse uses these windows\n  - mp week uses the current local calendar week for journal review.\n  - mp week prices the market window from the first Yahoo close matching the current local week when available.\n  - mp review period aliases filter journal timestamp dates; they are not fuzzy full-text search.\n",
+    );
+    out.push_str(
+        "\nBoundary\n  Calendar windows are local-date helpers for market literacy, not exchange-holiday calendars or trading signals.\n",
+    );
+    out
+}
+
 fn journal_path() -> PathBuf {
     if let Ok(home) = env::var("MARKET_PULSE_HOME") {
         return PathBuf::from(home).join("journal.jsonl");
@@ -2132,6 +2221,13 @@ fn read_events_for_date(limit: usize, date: &str) -> Vec<String> {
         return Vec::new();
     };
     filter_events_by_date(read_event_lines(&text), date, limit)
+}
+
+fn read_events_for_dates(limit: usize, dates: &[String]) -> Vec<String> {
+    let Ok(text) = fs::read_to_string(journal_path()) else {
+        return Vec::new();
+    };
+    filter_events_by_dates(read_event_lines(&text), dates, limit)
 }
 
 fn filter_events_by_date(events: Vec<String>, date: &str, limit: usize) -> Vec<String> {
@@ -2220,9 +2316,21 @@ fn render_review(limit: usize) -> String {
     render_review_from_events(&events, &journal_path().display().to_string())
 }
 
+fn render_review_for_filter(limit: usize, filter: &ReviewFilter) -> String {
+    match filter {
+        ReviewFilter::Date(date) => render_review_for_date(limit, date),
+        ReviewFilter::Dates { label, dates } => render_review_for_dates(limit, label, dates),
+    }
+}
+
 fn render_review_for_date(limit: usize, date: &str) -> String {
     let events = read_events_for_date(limit, date);
     render_review_for_date_from_events(&events, &journal_path().display().to_string(), date)
+}
+
+fn render_review_for_dates(limit: usize, label: &str, dates: &[String]) -> String {
+    let events = read_events_for_dates(limit, dates);
+    render_review_for_dates_from_events(&events, &journal_path().display().to_string(), label)
 }
 
 fn render_review_for_date_from_events(events: &[String], journal: &str, date: &str) -> String {
@@ -2232,6 +2340,17 @@ fn render_review_for_date_from_events(events: &[String], journal: &str, date: &s
         );
     }
     let mut out = format!("Review date filter: {date}\n\n");
+    out.push_str(&render_review_from_events(events, journal));
+    out
+}
+
+fn render_review_for_dates_from_events(events: &[String], journal: &str, label: &str) -> String {
+    if events.is_empty() {
+        return format!(
+            "No market-pulse journal entries found for {label}.\n\nJournal: {journal}\nTry `mp calendar` to inspect available date windows, or record one with `mp now`, `mp week`, `mp ask`, or `mp think`."
+        );
+    }
+    let mut out = format!("Review period filter: {label}\n\n");
     out.push_str(&render_review_from_events(events, journal));
     out
 }
@@ -2506,6 +2625,18 @@ mod tests {
         assert_eq!(
             parse_command(&["weekly".into(), "--no-save".into()]).unwrap(),
             CommandKind::Week
+        );
+    }
+
+    #[test]
+    fn routes_calendar_to_calendar_command() {
+        assert_eq!(
+            parse_command(&["calendar".into()]).unwrap(),
+            CommandKind::Calendar
+        );
+        assert_eq!(
+            parse_command(&["cal".into()]).unwrap(),
+            CommandKind::Calendar
         );
     }
 
@@ -2834,6 +2965,51 @@ mod tests {
         assert!(filtered[0].contains("10:00:00"));
         assert!(filtered[1].contains("\"type\":\"week\""));
         assert!(filtered[2].contains("11:00:00"));
+    }
+
+    #[test]
+    fn review_period_filter_renders_label_and_matching_dates() {
+        let events = vec![
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-19T09:00:00+0900\",\"text\":\"유가\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-20T10:00:00+0900\",\"text\":\"금리\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"inquiry\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"question\":\"달러와 코스피?\",\"thesis_type\":\"dollar-liquidity transmission thesis\",\"concepts\":\"dollar liquidity\"}".into(),
+        ];
+        let dates = vec!["2026-04-20".into(), "2026-04-21".into()];
+        let filtered = filter_events_by_dates(events, &dates, 10);
+        let out = render_review_for_dates_from_events(
+            &filtered,
+            "/tmp/journal.jsonl",
+            "this-week 2026-04-20..2026-04-21",
+        );
+        assert!(out.contains("Review period filter: this-week 2026-04-20..2026-04-21"));
+        assert!(out.contains("Entries scanned: 2"));
+        assert!(out.contains("rates"));
+        assert!(out.contains("fx"));
+        assert!(!out.contains("oil"));
+    }
+
+    #[test]
+    fn review_rejects_multiple_period_selectors() {
+        assert!(review(&["review".into(), "--today".into(), "--this-week".into()]).is_err());
+        assert!(review(&[
+            "review".into(),
+            "--date".into(),
+            "2026-04-21".into(),
+            "--last-week".into(),
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn calendar_renders_review_shortcuts_and_boundary() {
+        let out = render_calendar();
+        assert!(out.contains("Market Pulse Calendar"));
+        assert!(out.contains("today:"));
+        assert!(out.contains("this-week:"));
+        assert!(out.contains("last-week:"));
+        assert!(out.contains("mp review --this-week"));
+        assert!(out.contains("not fuzzy full-text search"));
+        assert!(out.contains("not exchange-holiday calendars"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,8 +196,8 @@ enum CommandKind {
 
 const PULSE_QUOTE_BASIS: &[&str] = &[
     "time: local machine timestamp and session label",
-    "change: latest Yahoo regularMarketPrice vs chartPreviousClose/fallback prior daily close",
-    "window: Yahoo chart range=5d interval=1d; quote-session pulse, not exact 24h, calendar-day, or weekly return",
+    "change: latest Yahoo daily close value vs prior daily close; regularMarketPrice is fallback only",
+    "window: Yahoo chart range=5d interval=1d; close-to-close pulse, not high/low gap, exact 24h, or weekly return",
 ];
 
 const REGIME_QUOTE_BASIS: &[&str] = &[
@@ -989,7 +989,7 @@ fn build_regime() -> Regime {
 
 #[derive(Clone, Debug)]
 enum WindowChange {
-    PreviousClose,
+    PriorDailyClose,
     FirstClose,
     FirstMatchingDate(Vec<String>),
 }
@@ -999,7 +999,14 @@ fn fetch_asset(
     label: &'static str,
     unit: &'static str,
 ) -> Result<Asset, String> {
-    fetch_asset_window(symbol, label, unit, "5d", "1d", WindowChange::PreviousClose)
+    fetch_asset_window(
+        symbol,
+        label,
+        unit,
+        "5d",
+        "1d",
+        WindowChange::PriorDailyClose,
+    )
 }
 
 fn fetch_asset_window(
@@ -1031,15 +1038,7 @@ fn fetch_asset_window(
     }
     let body = String::from_utf8_lossy(&output.stdout);
     let closes = close_values(&body);
-    let value = number_after(&body, "\"regularMarketPrice\":").or_else(|| closes.last().copied());
-    let previous = match change_from {
-        WindowChange::PreviousClose => number_after(&body, "\"chartPreviousClose\":")
-            .or_else(|| closes.get(closes.len().saturating_sub(2)).copied()),
-        WindowChange::FirstClose => closes.first().copied(),
-        WindowChange::FirstMatchingDate(dates) => first_close_for_dates(&body, &dates)
-            .or_else(|| number_after(&body, "\"chartPreviousClose\":"))
-            .or_else(|| closes.last().copied()),
-    };
+    let (value, previous) = value_and_previous_for_window(&body, &closes, &change_from);
     let change = match (value, previous) {
         (Some(v), Some(p)) if p != 0.0 => Some(((v - p) / p) * 100.0),
         _ => None,
@@ -1052,6 +1051,37 @@ fn fetch_asset_window(
         change,
         note: None,
     })
+}
+
+fn value_and_previous_for_window(
+    body: &str,
+    closes: &[f64],
+    change_from: &WindowChange,
+) -> (Option<f64>, Option<f64>) {
+    let market_price = || number_after(body, "\"regularMarketPrice\":");
+    let latest_close = || closes.last().copied();
+    let prior_close = || {
+        closes
+            .len()
+            .checked_sub(2)
+            .and_then(|i| closes.get(i))
+            .copied()
+    };
+
+    let value = match change_from {
+        WindowChange::PriorDailyClose => latest_close().or_else(market_price),
+        _ => market_price().or_else(latest_close),
+    };
+    let previous = match change_from {
+        WindowChange::PriorDailyClose => {
+            prior_close().or_else(|| number_after(body, "\"chartPreviousClose\":"))
+        }
+        WindowChange::FirstClose => closes.first().copied(),
+        WindowChange::FirstMatchingDate(dates) => first_close_for_dates(body, dates)
+            .or_else(|| number_after(body, "\"chartPreviousClose\":"))
+            .or_else(|| closes.last().copied()),
+    };
+    (value, previous)
 }
 
 fn encode_symbol(symbol: &str) -> String {
@@ -3584,8 +3614,22 @@ mod tests {
         let rendered = render_pulse(&p, false);
         assert!(rendered.contains("Market puzzle / question seeds"));
         assert!(rendered.contains("Basis"));
-        assert!(rendered.contains("quote-session pulse"));
-        assert!(rendered.contains("not exact 24h, calendar-day, or weekly return"));
+        assert!(rendered.contains("close-to-close pulse"));
+        assert!(rendered.contains("not high/low gap, exact 24h, or weekly return"));
+    }
+
+    #[test]
+    fn now_change_prefers_daily_close_series_over_market_quote() {
+        let body = r#"{"meta":{"regularMarketPrice":200,"chartPreviousClose":150},"indicators":{"quote":[{"close":[100,110,121]}]}}"#;
+
+        let (value, previous) = value_and_previous_for_window(
+            body,
+            &close_values(body),
+            &WindowChange::PriorDailyClose,
+        );
+
+        assert_eq!(value, Some(121.0));
+        assert_eq!(previous, Some(110.0));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ const PULSE_QUOTE_BASIS: &[&str] = &[
 
 const REGIME_QUOTE_BASIS: &[&str] = &[
     "time: local machine timestamp; regime is broader than today's pulse",
-    "change: latest Yahoo regularMarketPrice vs first available close in the chart window",
+    "change: latest Yahoo weekly close value vs first available weekly close; regularMarketPrice is fallback only",
     "window: Yahoo chart range=3mo interval=1wk; this is a 1-3 month regime read, not a trading signal",
 ];
 
@@ -762,7 +762,7 @@ fn week_basis(dates: &[String]) -> Vec<String> {
     let window = week_window_label(dates);
     vec![
         format!("time: local machine timestamp; current-week window {window}; weekly is a learning loop, not a trading signal"),
-        "market window: Yahoo chart range=1mo interval=1d; change is latest regularMarketPrice vs first close matching the current local week, falling back to the latest available close if the asset has not traded this week".into(),
+        "market window: Yahoo chart range=1mo interval=1d; change is latest daily close vs first close matching the current local week; regularMarketPrice is fallback only, and assets without a current-week close fall back to the latest available close".into(),
         format!("journal window: current local calendar week {window}, filtered before the weekly card is saved"),
     ]
 }
@@ -1069,17 +1069,18 @@ fn value_and_previous_for_window(
     };
 
     let value = match change_from {
-        WindowChange::PriorDailyClose => latest_close().or_else(market_price),
-        _ => market_price().or_else(latest_close),
+        WindowChange::PriorDailyClose
+        | WindowChange::FirstClose
+        | WindowChange::FirstMatchingDate(_) => latest_close().or_else(market_price),
     };
     let previous = match change_from {
         WindowChange::PriorDailyClose => {
             prior_close().or_else(|| number_after(body, "\"chartPreviousClose\":"))
         }
         WindowChange::FirstClose => closes.first().copied(),
-        WindowChange::FirstMatchingDate(dates) => first_close_for_dates(body, dates)
-            .or_else(|| number_after(body, "\"chartPreviousClose\":"))
-            .or_else(|| closes.last().copied()),
+        WindowChange::FirstMatchingDate(dates) => {
+            first_close_for_dates(body, dates).or_else(|| closes.last().copied())
+        }
     };
     (value, previous)
 }
@@ -3537,6 +3538,8 @@ mod tests {
         let basis = week_basis(&dates);
         assert!(basis[0].contains("current-week window 2026-04-20..2026-04-21"));
         assert!(basis[1].contains("range=1mo interval=1d"));
+        assert!(basis[1].contains("latest daily close"));
+        assert!(basis[1].contains("regularMarketPrice is fallback only"));
         assert!(basis[2].contains("current local calendar week"));
     }
 
@@ -3633,6 +3636,45 @@ mod tests {
     }
 
     #[test]
+    fn week_change_prefers_daily_close_series_over_market_quote() {
+        let body = r#"{"timestamp":[1776643200,1776729600,1776816000],"meta":{"regularMarketPrice":200,"chartPreviousClose":150},"indicators":{"quote":[{"close":[100,110,121]}]}}"#;
+
+        let (value, previous) = value_and_previous_for_window(
+            body,
+            &close_values(body),
+            &WindowChange::FirstMatchingDate(vec!["2026-04-21".into()]),
+        );
+
+        assert_eq!(value, Some(121.0));
+        assert_eq!(previous, Some(110.0));
+    }
+
+    #[test]
+    fn week_change_without_matching_date_falls_back_to_latest_close() {
+        let body = r#"{"timestamp":[1776643200,1776729600],"meta":{"regularMarketPrice":200,"chartPreviousClose":150},"indicators":{"quote":[{"close":[100,110]}]}}"#;
+
+        let (value, previous) = value_and_previous_for_window(
+            body,
+            &close_values(body),
+            &WindowChange::FirstMatchingDate(vec!["2026-04-24".into()]),
+        );
+
+        assert_eq!(value, Some(110.0));
+        assert_eq!(previous, Some(110.0));
+    }
+
+    #[test]
+    fn regime_change_prefers_weekly_close_series_over_market_quote() {
+        let body = r#"{"meta":{"regularMarketPrice":200,"chartPreviousClose":150},"indicators":{"quote":[{"close":[100,110,121]}]}}"#;
+
+        let (value, previous) =
+            value_and_previous_for_window(body, &close_values(body), &WindowChange::FirstClose);
+
+        assert_eq!(value, Some(121.0));
+        assert_eq!(previous, Some(100.0));
+    }
+
+    #[test]
     fn regime_renders_timeframe_basis_and_boundaries() {
         let regime = compose_test_regime(vec![
             Asset {
@@ -3672,6 +3714,8 @@ mod tests {
         let rendered = render_regime(&regime);
         assert!(rendered.contains("Market Regime"));
         assert!(rendered.contains("1-3 month regime read"));
+        assert!(rendered.contains("latest Yahoo weekly close value"));
+        assert!(rendered.contains("regularMarketPrice is fallback only"));
         assert!(rendered.contains("Next better regime question"));
         assert!(rendered.contains("not investment advice"));
     }
@@ -3711,6 +3755,8 @@ mod tests {
         let rendered = render_week(&week, &events);
         assert!(rendered.contains("Weekly Market Pulse"));
         assert!(rendered.contains("1W Asset Map"));
+        assert!(rendered.contains("latest daily close"));
+        assert!(rendered.contains("regularMarketPrice is fallback only"));
         assert!(rendered.contains("This week's learning loop"));
         assert!(rendered.contains("Recurring journal themes"));
         assert!(rendered.contains("Next week check questions"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,18 @@ struct Regime {
 }
 
 #[derive(Clone, Debug)]
+struct Weekly {
+    timestamp: String,
+    basis: Vec<String>,
+    label: String,
+    assets: Vec<Asset>,
+    drivers: Vec<String>,
+    tensions: Vec<String>,
+    questions: Vec<String>,
+    notes: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
 struct Inquiry {
     timestamp: String,
     question: String,
@@ -171,6 +183,7 @@ struct Feedback {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum CommandKind {
     Now,
+    Week,
     Regime,
     Think,
     Review,
@@ -183,6 +196,12 @@ const PULSE_QUOTE_BASIS: &[&str] = &[
     "time: local machine timestamp and session label",
     "change: latest Yahoo regularMarketPrice vs chartPreviousClose, usually the prior regular-session close",
     "window: Yahoo chart range=5d interval=1d; this is a session/daily pulse, not a weekly return",
+];
+
+const WEEK_QUOTE_BASIS: &[&str] = &[
+    "time: local machine timestamp; weekly is a learning loop, not a trading signal",
+    "market window: Yahoo chart range=5d interval=1d, latest regularMarketPrice vs first available close",
+    "journal window: last 7 local dates from market-pulse JSONL, filtered before the weekly card is saved",
 ];
 
 const REGIME_QUOTE_BASIS: &[&str] = &[
@@ -213,6 +232,7 @@ pub fn main_entry() {
 fn run(args: Vec<String>) -> Result<(), String> {
     match parse_command(&args)? {
         CommandKind::Now => now(&args),
+        CommandKind::Week => week(&args),
         CommandKind::Regime => regime(&args),
         CommandKind::Think => think(&args),
         CommandKind::Review => review(&args),
@@ -229,6 +249,7 @@ fn parse_command(args: &[String]) -> Result<CommandKind, String> {
     match args.first().map(String::as_str) {
         None => Ok(CommandKind::Now),
         Some("now") => Ok(CommandKind::Now),
+        Some("week") | Some("weekly") => Ok(CommandKind::Week),
         Some("regime") => Ok(CommandKind::Regime),
         Some("think") => Ok(CommandKind::Think),
         Some("review") => Ok(CommandKind::Review),
@@ -275,7 +296,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp week [--no-save]\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N]"
     );
 }
 
@@ -287,6 +308,17 @@ fn now(args: &[String]) -> Result<(), String> {
         append_event(&pulse_json(&pulse))?;
     }
     println!("{}", render_pulse(&pulse, compact));
+    Ok(())
+}
+
+fn week(args: &[String]) -> Result<(), String> {
+    let no_save = args.iter().any(|a| a == "--no-save");
+    let weekly = build_week();
+    let events = read_week_events(120);
+    if !no_save {
+        append_event(&week_json(&weekly, events.len()))?;
+    }
+    println!("{}", render_week(&weekly, &events));
     Ok(())
 }
 
@@ -662,6 +694,57 @@ fn build_pulse() -> Pulse {
     }
 }
 
+fn build_week() -> Weekly {
+    let mut assets = Vec::new();
+    let mut failures = 0;
+    for (symbol, label, unit) in SYMBOLS {
+        match fetch_asset_window(symbol, label, unit, "5d", "1d", WindowChange::FirstClose) {
+            Ok(asset) => assets.push(asset),
+            Err(_) => {
+                failures += 1;
+                assets.push(Asset {
+                    symbol,
+                    label,
+                    unit,
+                    value: None,
+                    change: None,
+                    note: Some("weekly data unavailable".into()),
+                });
+            }
+        }
+    }
+    let mut notes = vec![
+        "weekly market window uses Yahoo Finance chart endpoint via curl".to_string(),
+        "weekly journal window is a rolling 7 local-date learning review".to_string(),
+    ];
+    if failures > 0 {
+        notes.push(format!(
+            "{failures} quote(s) unavailable; weekly read is partial"
+        ));
+    }
+    let avg_equity = avg_change(&assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
+    let label = infer_week_label(
+        avg_equity,
+        change_for(&assets, "DX-Y.NYB"),
+        change_for(&assets, "^TNX"),
+        change_for(&assets, "CL=F"),
+        change_for(&assets, "BTC-USD"),
+    );
+    let drivers = infer_week_drivers(&assets);
+    let tensions = infer_week_tensions(&assets, &label);
+    let questions = infer_week_questions(&assets, &label, &tensions);
+    Weekly {
+        timestamp: timestamp(),
+        basis: WEEK_QUOTE_BASIS.iter().map(|s| (*s).to_string()).collect(),
+        label,
+        assets,
+        drivers,
+        tensions,
+        questions,
+        notes,
+    }
+}
+
 fn build_regime() -> Regime {
     let mut assets = Vec::new();
     let mut failures = 0;
@@ -937,6 +1020,126 @@ fn infer_concept(tensions: &[String], drivers: &[String]) -> String {
         "risk-on / risk-off"
     }
     .into()
+}
+
+fn infer_week_label(
+    avg_equity: f64,
+    usd: Option<f64>,
+    rates: Option<f64>,
+    oil: Option<f64>,
+    btc: Option<f64>,
+) -> String {
+    let macro_pressure = usd.is_some_and(|v| v > 0.7)
+        || rates.is_some_and(|v| v > 1.5)
+        || oil.is_some_and(|v| v > 4.0);
+    let high_beta = btc.is_some_and(|v| v > 5.0);
+    if avg_equity > 1.5 && !macro_pressure {
+        "risk-on learning week"
+    } else if avg_equity > 0.5 && macro_pressure {
+        "equity resilience vs macro-pressure week"
+    } else if avg_equity < -1.5 && macro_pressure {
+        "de-risking / macro-pressure week"
+    } else if avg_equity < -1.5 {
+        "risk-off / growth-doubt week"
+    } else if high_beta && avg_equity >= 0.0 {
+        "high-beta liquidity watch week"
+    } else {
+        "mixed / transition learning week"
+    }
+    .into()
+}
+
+fn infer_week_drivers(assets: &[Asset]) -> Vec<String> {
+    let mut drivers = Vec::new();
+    if change_for(assets, "^IXIC").is_some_and(|v| v > 1.5) {
+        drivers.push("Nasdaq strength is the first place to test growth/AI leadership".into());
+    }
+    if avg_change(assets, &["^GSPC", "^IXIC", "^KS11"]).is_some_and(|v| v > 1.2) {
+        drivers.push("Equities are broadly higher over the weekly window".into());
+    }
+    if change_for(assets, "DX-Y.NYB").is_some_and(|v| v.abs() > 0.7)
+        || change_for(assets, "KRW=X").is_some_and(|v| v.abs() > 0.7)
+    {
+        drivers.push("Dollar/FX moved enough to check whether liquidity pressure mattered".into());
+    }
+    if change_for(assets, "^TNX").is_some_and(|v| v.abs() > 1.5) {
+        drivers.push("US 10Y yield moved enough to test the rates-vs-growth story".into());
+    }
+    if change_for(assets, "CL=F").is_some_and(|v| v.abs() > 4.0) {
+        drivers.push(
+            "Oil moved enough to keep inflation/margin narratives in the weekly review".into(),
+        );
+    }
+    if change_for(assets, "BTC-USD").is_some_and(|v| v.abs() > 5.0) {
+        drivers.push("BTC/high beta moved enough to check liquidity appetite".into());
+    }
+    if drivers.is_empty() {
+        drivers.push(
+            "No single weekly driver dominates; use the journal themes to choose what to study"
+                .into(),
+        );
+        drivers
+            .push("Compare equities, rates, dollar, oil, and your own repeated questions".into());
+    }
+    drivers.truncate(5);
+    drivers
+}
+
+fn infer_week_tensions(assets: &[Asset], label: &str) -> Vec<String> {
+    let mut tensions = Vec::new();
+    let avg_equity = avg_change(assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
+    if avg_equity > 0.5
+        && (change_for(assets, "^TNX").is_some_and(|v| v > 1.5)
+            || change_for(assets, "DX-Y.NYB").is_some_and(|v| v > 0.7))
+    {
+        tensions.push("weekly equity strength vs tighter financial-condition signals".into());
+    }
+    if change_for(assets, "^IXIC").unwrap_or(0.0) - change_for(assets, "^GSPC").unwrap_or(0.0) > 1.0
+    {
+        tensions.push("Nasdaq/growth leadership vs broad-market confirmation".into());
+    }
+    if change_for(assets, "^KS11").unwrap_or(0.0) < avg_equity - 1.0 {
+        tensions.push("Korea/EM follow-through vs US market story".into());
+    }
+    if change_for(assets, "CL=F").is_some_and(|v| v > 4.0) && avg_equity > 0.0 {
+        tensions.push("risk appetite vs oil/inflation impulse".into());
+    }
+    if label.contains("transition") {
+        tensions.push("this week's pulse may not match the broader regime".into());
+    }
+    if tensions.is_empty() {
+        tensions.push("headline weekly move vs cross-asset confirmation".into());
+    }
+    tensions.truncate(4);
+    tensions
+}
+
+fn infer_week_questions(assets: &[Asset], label: &str, tensions: &[String]) -> Vec<String> {
+    let text = format!("{label} {}", tensions.join(" ")).to_lowercase();
+    let mut questions = Vec::new();
+    if text.contains("financial-condition") || text.contains("rates") {
+        questions.push("Next week, do yields/dollar confirm or fight the equity story?".into());
+    }
+    if text.contains("nasdaq") || text.contains("growth") {
+        questions.push("Is leadership broadening beyond growth/AI, or still narrow?".into());
+    }
+    if text.contains("korea") || change_for(assets, "^KS11").is_some() {
+        questions
+            .push("Does KOSPI confirm the US story, or is FX/EM pressure still a drag?".into());
+    }
+    if text.contains("oil") || change_for(assets, "CL=F").is_some_and(|v| v.abs() > 4.0) {
+        questions
+            .push("Is oil changing inflation expectations, or staying sector-specific?".into());
+    }
+    questions.push("What would make you rename this week’s market story by next Friday?".into());
+    let mut unique = Vec::new();
+    for question in questions {
+        if !unique.contains(&question) {
+            unique.push(question);
+        }
+    }
+    unique.truncate(5);
+    unique
 }
 
 fn infer_regime_label(
@@ -1540,6 +1743,98 @@ fn render_regime(r: &Regime) -> String {
     out
 }
 
+fn render_week(w: &Weekly, events: &[String]) -> String {
+    let summary = summarize_events(events);
+    let mut out = format!(
+        "Weekly Market Pulse · {}\n\nWeek story\n  {}\n\nBasis\n",
+        w.timestamp, w.label
+    );
+    for b in &w.basis {
+        out.push_str(&format!("  - {b}\n"));
+    }
+    out.push_str("\n1W Asset Map\n");
+    for a in &w.assets {
+        let value = a
+            .value
+            .map(|v| {
+                format!(
+                    "{v:.2}{}",
+                    if a.unit.is_empty() {
+                        "".to_string()
+                    } else {
+                        format!(" {}", a.unit)
+                    }
+                )
+            })
+            .unwrap_or_else(|| "n/a".into());
+        let change = a
+            .change
+            .map(|c| format!("{:+.2}%", c))
+            .unwrap_or_else(|| "n/a".into());
+        let note = a
+            .note
+            .as_ref()
+            .map(|n| format!(" · {n}"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "  - {}: {} ({}){}\n",
+            a.label, value, change, note
+        ));
+    }
+    out.push_str("\nWeekly market themes\n");
+    for (i, d) in w.drivers.iter().enumerate() {
+        out.push_str(&format!("  {}. {}\n", i + 1, d));
+    }
+    out.push_str("\nWeekly tensions\n");
+    for t in &w.tensions {
+        out.push_str(&format!("  - {t}\n"));
+    }
+    out.push_str(&format!(
+        "\nThis week's learning loop\n  Entries scanned: {} · pulses {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n",
+        events.len(),
+        summary.pulses,
+        summary.regimes,
+        summary.inquiries,
+        summary.research_inquiries,
+        summary.thoughts,
+        summary.feedback
+    ));
+    out.push_str("\nRecurring journal themes\n");
+    let mut wrote_themes = false;
+    for (tag, count) in summary
+        .tag_counts
+        .iter()
+        .filter(|(_, count)| *count > 0)
+        .take(5)
+    {
+        wrote_themes = true;
+        out.push_str(&format!("  - {tag}: {count}\n"));
+    }
+    if !wrote_themes {
+        out.push_str("  - Not enough tagged questions/thoughts this week yet\n");
+    }
+    out.push_str("\nQuestion / thesis habits\n");
+    if summary.thesis_types.is_empty() {
+        out.push_str("  - Ask or think at least once this week to build a visible pattern.\n");
+    } else {
+        for thesis in summary.thesis_types.iter().take(4) {
+            out.push_str(&format!("  - You used a {thesis} lens.\n"));
+        }
+    }
+    out.push_str("\nNext week check questions\n");
+    for q in &w.questions {
+        out.push_str(&format!("  - {q}\n"));
+    }
+    out.push_str("\nWeekly drill\n  Pick one repeated theme above and write one falsifiable `mp think` note before the next `mp-week`.\n\nBoundary\n  Market literacy only; not investment advice, buy/sell guidance, price targets, stop-loss, or portfolio instructions.\n");
+    if !w.notes.is_empty() {
+        out.push_str("\nSource notes\n");
+        for n in &w.notes {
+            out.push_str(&format!("  - {n}\n"));
+        }
+    }
+    out
+}
+
 fn question_seeds_for(p: &Pulse) -> Vec<String> {
     let text = format!(
         "{} {} {}",
@@ -1726,6 +2021,18 @@ fn read_events(limit: usize) -> Vec<String> {
     limit_events(read_event_lines(&text), limit)
 }
 
+fn read_week_events(limit: usize) -> Vec<String> {
+    let Ok(text) = fs::read_to_string(journal_path()) else {
+        return Vec::new();
+    };
+    let events = read_event_lines(&text);
+    let dates = date_prefixes_for_days(7);
+    if dates.is_empty() {
+        return limit_events(events, limit);
+    }
+    filter_events_by_dates(events, &dates, limit)
+}
+
 fn read_event_lines(text: &str) -> Vec<String> {
     text.lines()
         .filter(|l| !l.trim().is_empty())
@@ -1753,6 +2060,23 @@ fn filter_events_by_date(events: Vec<String>, date: &str, limit: usize) -> Vec<S
         .filter(|l| event_matches_date(l, date))
         .collect::<Vec<_>>();
     limit_events(lines, limit)
+}
+
+fn filter_events_by_dates(events: Vec<String>, dates: &[String], limit: usize) -> Vec<String> {
+    let lines = events
+        .into_iter()
+        .filter(|l| {
+            json_field(l, "timestamp")
+                .is_some_and(|ts| dates.iter().any(|date| ts.starts_with(date)))
+        })
+        .collect::<Vec<_>>();
+    limit_events(lines, limit)
+}
+
+fn date_prefixes_for_days(days: u32) -> Vec<String> {
+    (0..days)
+        .filter_map(|days_ago| date_for_days_ago(days_ago).ok())
+        .collect()
 }
 
 fn event_matches_date(line: &str, date: &str) -> bool {
@@ -1832,35 +2156,28 @@ fn render_review_for_date_from_events(events: &[String], journal: &str, date: &s
     out
 }
 
-fn render_review_from_events(events: &[String], journal: &str) -> String {
-    if events.is_empty() {
-        return "No market-pulse journal entries yet. Start with `mp \"your market question\"`, then `mp think \"...\"`.".into();
-    }
-    let pulses = events
-        .iter()
-        .filter(|l| l.contains("\"type\":\"pulse\""))
-        .count();
-    let thoughts = events
-        .iter()
-        .filter(|l| l.contains("\"type\":\"thought\""))
-        .count();
-    let regimes = events
-        .iter()
-        .filter(|l| l.contains("\"type\":\"regime\""))
-        .count();
-    let inquiries = events
-        .iter()
-        .filter(|l| l.contains("\"type\":\"inquiry\""))
-        .count();
-    let research_inquiries = events
-        .iter()
-        .filter(|l| l.contains("\"type\":\"research_inquiry\""))
-        .count();
-    let feedback = events
-        .iter()
-        .filter(|l| l.contains("\"type\":\"feedback\""))
-        .count();
-    let mut counts: Vec<(&str, usize)> = vec![
+#[derive(Clone, Debug)]
+struct JournalSummary {
+    pulses: usize,
+    weeks: usize,
+    regimes: usize,
+    inquiries: usize,
+    research_inquiries: usize,
+    thoughts: usize,
+    feedback: usize,
+    tag_counts: Vec<(&'static str, usize)>,
+    thesis_types: Vec<String>,
+}
+
+fn summarize_events(events: &[String]) -> JournalSummary {
+    let pulses = count_events(events, "pulse");
+    let weeks = count_events(events, "week");
+    let regimes = count_events(events, "regime");
+    let inquiries = count_events(events, "inquiry");
+    let research_inquiries = count_events(events, "research_inquiry");
+    let thoughts = count_events(events, "thought");
+    let feedback = count_events(events, "feedback");
+    let mut tag_counts: Vec<(&str, usize)> = vec![
         ("rates", 0),
         ("semis", 0),
         ("fx", 0),
@@ -1884,17 +2201,45 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
             thesis_types.push(detect_thesis_type(&tags));
         }
         for tag in tags {
-            if let Some((_, count)) = counts.iter_mut().find(|(name, _)| *name == tag) {
+            if let Some((_, count)) = tag_counts.iter_mut().find(|(name, _)| *name == tag) {
                 *count += 1;
             }
         }
     }
-    counts.sort_by(|a, b| b.1.cmp(&a.1));
+    tag_counts.sort_by(|a, b| b.1.cmp(&a.1));
     thesis_types.sort();
     thesis_types.dedup();
-    let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), pulses, regimes, inquiries, research_inquiries, thoughts, feedback);
+    JournalSummary {
+        pulses,
+        weeks,
+        regimes,
+        inquiries,
+        research_inquiries,
+        thoughts,
+        feedback,
+        tag_counts,
+        thesis_types,
+    }
+}
+
+fn count_events(events: &[String], event_type: &str) -> usize {
+    let needle = format!("\"type\":\"{event_type}\"");
+    events.iter().filter(|l| l.contains(&needle)).count()
+}
+
+fn render_review_from_events(events: &[String], journal: &str) -> String {
+    if events.is_empty() {
+        return "No market-pulse journal entries yet. Start with `mp \"your market question\"`, then `mp think \"...\"`.".into();
+    }
+    let summary = summarize_events(events);
+    let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), summary.pulses, summary.weeks, summary.regimes, summary.inquiries, summary.research_inquiries, summary.thoughts, summary.feedback);
     let mut wrote = false;
-    for (tag, count) in counts.into_iter().filter(|(_, c)| *c > 0).take(6) {
+    for (tag, count) in summary
+        .tag_counts
+        .into_iter()
+        .filter(|(_, c)| *c > 0)
+        .take(6)
+    {
         wrote = true;
         out.push_str(&format!("  - {tag}: {count}\n"));
     }
@@ -1902,10 +2247,10 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
         out.push_str("  - Not enough tagged thoughts yet\n");
     }
     out.push_str("\nQuestion / thesis habits\n");
-    if thesis_types.is_empty() {
+    if summary.thesis_types.is_empty() {
         out.push_str("  - Not enough inquiry/thesis history yet; ask one rough question with `mp \"...\"`.\n");
     } else {
-        for t in thesis_types.iter().take(5) {
+        for t in summary.thesis_types.iter().take(5) {
             out.push_str(&format!("  - You have been using a {t} lens.\n"));
         }
     }
@@ -1932,6 +2277,17 @@ fn regime_json(r: &Regime) -> String {
         esc(&r.basis.join(" | ")),
         esc(&r.label),
         esc(&r.question)
+    )
+}
+
+fn week_json(w: &Weekly, journal_entries: usize) -> String {
+    format!(
+        "{{\"type\":\"week\",\"timestamp\":\"{}\",\"basis\":\"{}\",\"label\":\"{}\",\"journal_entries\":{},\"question\":\"{}\"}}",
+        esc(&w.timestamp),
+        esc(&w.basis.join(" | ")),
+        esc(&w.label),
+        journal_entries,
+        esc(w.questions.first().map(String::as_str).unwrap_or(""))
     )
 }
 
@@ -2058,6 +2414,18 @@ mod tests {
         assert_eq!(
             parse_command(&["regime".into(), "--no-save".into()]).unwrap(),
             CommandKind::Regime
+        );
+    }
+
+    #[test]
+    fn routes_week_to_week_command() {
+        assert_eq!(
+            parse_command(&["week".into(), "--no-save".into()]).unwrap(),
+            CommandKind::Week
+        );
+        assert_eq!(
+            parse_command(&["weekly".into(), "--no-save".into()]).unwrap(),
+            CommandKind::Week
         );
     }
 
@@ -2373,6 +2741,20 @@ mod tests {
     }
 
     #[test]
+    fn week_date_filter_keeps_last_matching_dates() {
+        let events = vec![
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-19T09:00:00+0900\",\"text\":\"유가\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-20T10:00:00+0900\",\"text\":\"금리\",\"linked_pulse_timestamp\":null}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T11:00:00+0900\",\"text\":\"달러\",\"linked_pulse_timestamp\":null}".into(),
+        ];
+        let dates = vec!["2026-04-20".into(), "2026-04-21".into()];
+        let filtered = filter_events_by_dates(events, &dates, 10);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered[0].contains("10:00:00"));
+        assert!(filtered[1].contains("11:00:00"));
+    }
+
+    #[test]
     fn review_date_validation_rejects_non_iso_date() {
         assert!(validate_review_date("2026-04-21").is_ok());
         assert!(validate_review_date("20260421").is_err());
@@ -2483,6 +2865,48 @@ mod tests {
         assert!(rendered.contains("not investment advice"));
     }
 
+    #[test]
+    fn week_renders_hybrid_market_and_learning_card() {
+        let week = compose_test_week(vec![
+            Asset {
+                symbol: "^IXIC",
+                label: "Nasdaq",
+                unit: "",
+                value: Some(100.0),
+                change: Some(2.0),
+                note: None,
+            },
+            Asset {
+                symbol: "^GSPC",
+                label: "S&P 500",
+                unit: "",
+                value: Some(100.0),
+                change: Some(1.0),
+                note: None,
+            },
+            Asset {
+                symbol: "^TNX",
+                label: "US 10Y",
+                unit: "%",
+                value: Some(4.8),
+                change: Some(1.8),
+                note: None,
+            },
+        ]);
+        let events = vec![
+            "{\"type\":\"inquiry\",\"timestamp\":\"2026-04-21T09:00:00+0900\",\"question\":\"금리와 반도체가 같이 움직이나?\",\"thesis_type\":\"rates/growth tension thesis\",\"concepts\":\"rates vs growth\"}".into(),
+            "{\"type\":\"thought\",\"timestamp\":\"2026-04-21T10:00:00+0900\",\"text\":\"달러가 강한데 코스피가 버틴다\",\"linked_pulse_timestamp\":null}".into(),
+        ];
+        let rendered = render_week(&week, &events);
+        assert!(rendered.contains("Weekly Market Pulse"));
+        assert!(rendered.contains("1W Asset Map"));
+        assert!(rendered.contains("This week's learning loop"));
+        assert!(rendered.contains("Recurring journal themes"));
+        assert!(rendered.contains("Next week check questions"));
+        assert!(rendered.contains("rates"));
+        assert!(rendered.contains("not investment advice"));
+    }
+
     fn compose_test_pulse(assets: Vec<Asset>) -> Pulse {
         let avg_equity = avg_change(&assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
         let mood = infer_mood(
@@ -2526,6 +2950,29 @@ mod tests {
                 .collect(),
             question: infer_regime_question(&label, &tensions),
             checks: infer_regime_checks(&assets, &label),
+            label,
+            assets,
+            drivers,
+            tensions,
+            notes: vec![],
+        }
+    }
+
+    fn compose_test_week(assets: Vec<Asset>) -> Weekly {
+        let avg_equity = avg_change(&assets, &["^GSPC", "^IXIC", "^KS11"]).unwrap_or(0.0);
+        let label = infer_week_label(
+            avg_equity,
+            change_for(&assets, "DX-Y.NYB"),
+            change_for(&assets, "^TNX"),
+            change_for(&assets, "CL=F"),
+            change_for(&assets, "BTC-USD"),
+        );
+        let drivers = infer_week_drivers(&assets);
+        let tensions = infer_week_tensions(&assets, &label);
+        Weekly {
+            timestamp: timestamp(),
+            basis: WEEK_QUOTE_BASIS.iter().map(|s| (*s).to_string()).collect(),
+            questions: infer_week_questions(&assets, &label, &tensions),
             label,
             assets,
             drivers,


### PR DESCRIPTION
## Summary

- Add readable Codex/OMX alias skills for `$mp-now`, `$mp-week`, `$mp-calendar`, `$mp-find`, `$mp-regime`, `$mp-ask`, `$mp-research`, `$mp-think`, and `$mp-review`.
- Add `mp week`, a hybrid weekly market-and-learning card that combines a current-local-week market map, current-week journal themes, thesis habits, and next-week check questions.
- Add `mp calendar`, a small local-date window helper that shows `today`, `yesterday`, `this-week`, `last-week`, and the matching review shortcuts.
- Add `mp find <query>`, a local journal recall card that searches prior market-pulse entries with optional date/window selectors and turns matches into a learning prompt.
- Strengthen the shared recommended-question lens so `mp ask` / `mp research`, `mp think`, `mp find`, `mp week`, and `mp review` push evidence, falsification, and alternative-hypothesis thinking instead of generic follow-ups.
- Shorten the strengthened follow-up prompt wording so the validation lens stays compact enough for terminal cards.
- Add Hangul-sensitive follow-up prompts so Korean `mp ask`, `mp think`, `mp find`, and Korean-journal `mp review` flows answer the validation loop in Korean while English input remains English.
- Anchor `mp week` to the current local ISO week from the current date, using Yahoo `range=1mo&interval=1d` to find the first close matching the current local week and falling back safely if an asset has not traded this week.
- Add `mp regime`, a 1-3 month market-regime card that stays separate from the session/daily `mp now` pulse and the weekly learning card.
- Add `mp review --date YYYY-MM-DD`, preferred `mp review --days N`, and small readable calendar selectors: `--today`, `--yesterday`, `--this-week`, and `--last-week`; `--ago N` / `--days-ago N` remain compatibility aliases.
- Document Codex and Claude adapter usage, install steps, and the phased decision to keep broader natural-language search, exchange calendars, and semantic search deferred.
- Clarify `mp now`, `mp week`, `mp calendar`, `mp find`, and `mp regime` bases so session, local-date review windows, journal recall, current-week context, and 1-3 month context are not conflated.

- Clarify `mp now` as a quote-session pulse rather than an exact 24-hour/calendar-day return, and add a mixed-session source note for US indices, Korea, FX, futures, and crypto.

- Change `mp now` default percentage math from primary `regularMarketPrice` vs previous close to Yahoo daily close-series close-to-close, keeping `regularMarketPrice` as fallback only so the card does not read like a gap/high-low or live quote jump.

- Apply the same close-series rule to dated windows: `mp week` now compares latest daily close vs first current-week close, and `mp regime` compares latest weekly close vs first 1-3 month weekly close, with `regularMarketPrice` fallback only.

## Why

The intended workflow happens inside Codex/OMX sessions, where `$...` invocations are the natural interaction surface. The alias surface reduces repeated `mp ask` / `mp research` / `mp think` typing while keeping market-pulse behavior delegated to the Rust CLI.

`$mp-week` now has a distinct job: it is not another daily card and not a broad regime read. It closes the learning loop by showing what the market did during the current local week alongside what the user actually asked/thought during the same local-week window, then turns that into next-week checks.

`$mp-calendar` is intentionally smaller than fuzzy natural-language search. It makes the current local date windows visible and memorable, then points to exact `mp review` selectors. That gives the user fast `오늘/어제/이번주/지난주` recall without pretending market-pulse has exchange-holiday calendars or broad natural-language parsing yet.

`$mp-find` is the next risk-reduction step: after the user records thoughts and questions, they need a quick way to find prior thinking. The first pass searches the local JSONL journal only and renders a recall card with matching entries, counts, recurring themes, a next recall question, and a local-journal-only boundary. It deliberately avoids exchange-calendar semantics, live provider changes, fuzzy date parsing, semantic/vector search, and trading advice.

The regime card adds the larger backdrop traders compare against short-term moves without turning `mp now` into a crowded multi-timeframe dashboard. Date-filtered, `--days`, small period-alias review, and explicit journal find let users recover what they recorded on a specific day/window before adding broader fuzzy search.

The latest prompt-quality pass keeps question generation deterministic and local: no LLM calls, no new dependencies, no provider changes, and no trading advice. The improvement is intentionally product-shaped: every surface should make the user ask what evidence confirms the interpretation, what would falsify it, and what alternative could explain the same tape. Korean free-text inputs now keep that follow-up loop in Korean for the core ask/think/find/review learning path.

## Validation

- `cargo fmt --check`
- `cargo test` — 42 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- `cargo run --bin mp -- now --no-save`
- `cargo run --bin mp -- regime --no-save`
- `cargo run --bin mp -- week --no-save` live Yahoo smoke, showing current-week window `2026-04-20..2026-04-21` in the earlier weekly pass
- `cargo run --quiet --bin mp -- calendar` smoke, showing local windows `today=2026-04-22`, `yesterday=2026-04-21`, `this-week=2026-04-20..2026-04-22`, `last-week=2026-04-13..2026-04-19`
- Fixture `cargo run --quiet --bin mp -- review --this-week` smoke — period filter `this-week 2026-04-20..2026-04-22`, 3 entries scanned
- Fixture `cargo run --quiet --bin mp -- review --last-week` smoke — period filter `last-week 2026-04-13..2026-04-19`, 1 entry scanned
- Fixture `cargo run --quiet --bin mp -- review --yesterday` smoke — date filter `2026-04-21`, 1 entry scanned
- Fixture `cargo run --quiet --bin mp -- find 금리 --this-week` smoke — 2 matched current-week entries and recall question
- Fixture `cargo run --quiet --bin mp -- find 달러 --last-week` smoke — 1 matched last-week entry and recall question
- Fixture `cargo run --quiet --bin mp -- find 반도체 --last-week` empty-result smoke
- `cargo run --bin mp -- review --date 2026-04-21` with fixture journal
- `cargo run --bin mp -- review --days 1` with fixture journal
- Compatibility `cargo run --bin mp -- review --ago 1` smoke
- `cargo run --bin mp -- review --days-ago 0 --limit 1` with fixture journal
- Live `cargo run --quiet --bin mp -- now --no-save` smoke after the prompt-quality pass
- Live `cargo run --quiet --bin mp -- week --no-save` smoke after the prompt-quality pass
- Live `cargo run --quiet --bin mp -- regime --no-save` smoke after the prompt-quality pass
- `cargo run --quiet --bin mp -- ask "금리가 내려가는데 반도체가 강한 건 완화 기대인가?" --no-save` smoke — compact Next better question asks in Korean for evidence that growth leadership is absorbing rate pressure
- Korean `cargo run --quiet --bin mp -- think "금리가 부담인데도 반도체가 버티는 것 같다" --no-save` smoke — Next questions rendered in Korean
- Korean fixture `MARKET_PULSE_HOME=... cargo run --quiet --bin mp -- review --this-week` smoke — Suggested drill rendered in Korean for Korean journal entries
- Fixture `MARKET_PULSE_HOME=... cargo run --quiet --bin mp -- find 금리 --this-week` smoke — compact recall question includes the date window and Korean 금리·달러 falsifier
- Empty-date, invalid-date, and invalid-days review smokes
- `cargo install --path . --force`
- Installed `mp calendar` smoke
- Installed fixture smokes for `mp review --this-week`, `mp review --last-week`, and `mp review --yesterday`
- Installed fixture smoke for `mp find 금리 --today`
- Installed `mp ask "금리가 내려가는데 반도체가 강한 건 완화 기대인가?" --no-save` smoke
- Installed Korean `mp ask "금리가 내려가는데 반도체가 강한 건 완화 기대인가?" --no-save` smoke
- Installed fixture `MARKET_PULSE_HOME=... mp find 금리 --this-week` smoke
- Alias source/install parity checks for local `~/.codex/skills/mp-week`, `~/.codex/skills/mp-calendar`, `~/.codex/skills/mp-find`, `~/.codex/skills/mp-regime`, and `~/.codex/skills/mp-review`
- Previous architect verification: APPROVED

- Latest quote-basis clarity pass: `cargo fmt --check`; `cargo test` — 42 passed; `cargo clippy --all-targets --all-features -- -D warnings`; `git diff --check`; `cargo run --quiet --bin mp -- now --no-save` showing the new quote-session basis wording.

- Latest close-to-close pass: `cargo fmt --check`; `cargo test` — 43 passed; `cargo clippy --all-targets --all-features -- -D warnings`; `git diff --check`; `cargo run --quiet --bin mp -- now --no-save`; `cargo install --path . --force`; installed `mp now` smoke showing close-to-close basis and populated live values.

- Latest dated-window close-series pass: `cargo fmt --check`; `cargo test` — 46 passed; `cargo clippy --all-targets --all-features -- -D warnings`; `git diff --check`; `cargo run --quiet --bin mp -- week --no-save`; `cargo run --quiet --bin mp -- regime --no-save`; `cargo install --path . --force`; installed `mp week` / `mp regime` smokes showing close-series basis wording and populated live values.

## Notes

New local Codex skill names may require restarting or reloading the current Codex/OMX session before `$mp-week`, `$mp-calendar`, `$mp-find`, `$mp-regime`, and the other aliases appear in the skill list.

Natural-language date lookup such as `$mp-review "어제/지난주"`, full-text query phrasing beyond explicit `mp find <query>`, exchange-calendar-aware sessions, semantic/vector search, live provider polish, live LLM-backed prompt generation, full Korean localization of every static section header, and deeper regime/weekly heuristic quality work remain deliberately deferred to follow-up phases.






