### PR TITLE
Add daily radar and FOMO checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ mp "금리가 내려간 게 진짜 완화 기대 때문임?"
 mp research "금리 하락이 성장주에 좋은 신호임?"
 mp "대형 IPO 때문에 성장주가 강한 걸까?" --research
 mp ask "대형 IPO 때문에 성장주가 강한 걸까?"
+mp 오늘 시황
+mp NVDA
+mp NVDA 리서치
+mp 전에 금리 찾아줘 --limit 3
+mp 이번주 복기
 mp now
+mp watch
+mp fomo
 mp week
 mp calendar
 mp regime
@@ -63,6 +70,36 @@ Explicit alias for the same inquiry flow:
 ```bash
 mp ask "대형 IPO가 시장 상승 이유가 될 수 있음?"
 ```
+
+### Natural Korean/ticker aliases
+
+The CLI includes a small deterministic router for common Korean daily-use
+phrases and ticker/company/asset-like text. It is an alias layer, not a full
+NLP engine:
+
+```bash
+mp 오늘 시황              # same current-market card as mp now
+mp 지금 시장
+mp 시장 펄스
+mp 이번주                # same weekly card as mp week
+mp 레짐                  # same broader backdrop card as mp regime
+mp 캘린더                # same local calendar card as mp calendar
+mp 오늘 복기             # normalized to mp review --today
+mp 지난주 리뷰 --limit 5 # normalized to mp review --last-week --limit 5
+mp 전에 금리 찾아줘      # normalized to mp find "금리"
+mp 내 생각 나스닥은 너무 오른듯
+mp NVDA                  # safe inquiry scaffold
+mp 비트코인              # safe inquiry scaffold
+mp NVDA 리서치           # source-aware research scaffold
+mp 반도체 왜 오름?       # source-aware research scaffold
+```
+
+Explicit commands still win. For example, `mp now 리서치` remains `mp now`,
+while `mp 오늘 시황 근거` and `mp 오늘 시황 --research` intentionally route to
+research mode. Ticker/company/asset-like text by itself stays in the safe local
+inquiry scaffold; source-aware output requires `research`, `--research`, or an
+evidence/source marker such as `리서치`, `근거`, `출처`, `왜`, `뉴스`, `자료`, or
+`확인`, `팩트체크`.
 
 ### `mp research "question"` / `mp "question" --research`
 
@@ -132,13 +169,47 @@ Prints a compact market pulse card:
 
 - market mood
 - asset pressure
+- Semis (`^SOX`) as a non-compact semiconductor index proxy, not a full AI basket
 - likely tensions
 - market puzzle / question seeds
 - one concept to watch
+- a six-line Daily Decision Checklist in non-compact output: scenario,
+  confirm, falsify, watch, discipline, and journal prompt
 
 Live quotes are fetched through the Yahoo Finance chart endpoint by shelling out to `curl`. If a quote fails, the card still renders so the learning loop is not blocked.
 
 `mp now` is a close-to-close pulse, not a high/low gap, exact 24-hour, local calendar-day, or weekly return screen. The timestamp and session label use the local machine clock, while each percentage move is calculated from Yahoo `range=5d&interval=1d` daily closes: latest daily close value versus prior daily close. `regularMarketPrice` is fallback only when the close series is unavailable. Because US indices, Korea, FX, futures, and crypto use different clocks, treat the card as a cross-asset directional snapshot and use `$mp-research` when the exact exchange calendar matters.
+
+The Daily Decision Checklist is an observation and journaling routine, not a
+trade instruction. It helps name a scenario, define confirmation/falsification,
+watch cross-asset relationships, and write a `mp think` note before forming a
+market view. When `^SOX` data is available, the checklist may use Semis-led
+scenario language; without that data it falls back to non-semis wording. `mp now
+--compact` remains a one-line pulse and does not render the checklist.
+
+### `mp watch`
+
+Prints a Daily Radar card for the “what should I keep in mind today?” use case:
+
+- current mood and quote/change basis
+- scenario / watch / confirm / falsify lines derived from the same cross-asset pulse logic as `mp now`
+- a short driver/tension summary
+- a FOMO checkpoint prompt that separates evidence from opportunity-cost fear
+- explicit boundary: reasoning support only, no trading instructions
+
+`mp watch` saves a `radar` journal event unless `--no-save` is passed. The saved event is intentionally compact JSONL: timestamp, linked pulse timestamp, mood, scenario, confirm, falsify, watch, and prompt. It is designed to make `mp review` / `mp find` catch daily market context later without requiring a daemon, OS push notification, external messenger, paid API, or GUI.
+
+### `mp fomo`
+
+Prints a lightweight FOMO checkpoint for moments when the tape feels hard to ignore:
+
+- latest saved radar and pulse timestamps when available
+- latest scenario carried forward from `mp watch`
+- pause questions: what exactly am I reacting to, what confirms it, what falsifies it, and is this evidence or opportunity-cost fear?
+- a next journal prompt for `mp think`
+- explicit boundary: reasoning support only, no trading instructions
+
+`mp fomo` saves a `fomo_check` journal event unless `--no-save` is passed. If no prior radar exists, it still renders a useful pause card and suggests running `mp watch` for a fresh context card.
 
 ### `mp regime`
 
@@ -170,16 +241,23 @@ Prints a hybrid weekly market-and-learning card:
 
 ### `mp calendar`
 
-Prints the local-date windows market-pulse uses for review shortcuts:
+Prints a compact market-calendar report. It still shows the local-date windows
+market-pulse uses for journal review, but now adds static exchange-session
+context so `mp now` / `mp week` close-based readings are easier to interpret:
 
 - today
 - yesterday
 - this-week
 - last-week
+- US equities (NYSE/Nasdaq) regular-session reference: 09:30-16:00 ET
+- Korea equities (KRX/KOSPI) regular-session reference: 09:00-15:30 KST
+- a calendar-to-pulse bridge for daily close-to-close and current-week close basis
 - matching `mp review` shortcut commands
-- explicit boundary that these are local-date helpers, not exchange-holiday calendars or trading signals
+- explicit boundary that this is a static MVP, not a full official
+  holiday/early-close calendar, live event calendar, or trading signal
 
-Use it when you forget which date window a shortcut means:
+Use it when you want to check both the journal date window and the equity-session
+context behind the latest market pulse:
 
 ```bash
 mp calendar
@@ -219,11 +297,15 @@ mp find "유가" --last-week
 mp find "반도체" --days 3 --limit 5
 ```
 
-`mp search` is accepted as a thin alias for `mp find`. The first pass is intentionally explicit: it does not parse arbitrary natural-language dates, does not use exchange calendars, does not call live web providers, and does not add semantic/vector search.
+`mp search` is accepted as a thin alias for `mp find`. A small deterministic
+Korean recall alias layer also accepts phrases such as `mp 전에 금리 찾아줘` and
+normalizes them to command-shaped `mp find` arguments. It does not parse
+arbitrary natural-language dates, does not use exchange calendars, does not call
+live web providers, and does not add semantic/vector search.
 
 ### `mp review`
 
-Reviews recent pulses, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
+Reviews recent pulses, radars, FOMO checkpoints, regimes, inquiries, thoughts, and feedback to surface recurring themes, question habits, and reasoning drills.
 
 Use `--date YYYY-MM-DD` to review only entries recorded on a specific timestamp date, `--days N` for the common “N days back” flow, or small readable aliases for common calendar windows:
 
@@ -236,16 +318,19 @@ mp review --this-week
 mp review --last-week
 ```
 
-`--limit N` can be combined with one date/window selector; the limit is applied after matching, keeping the most recent matching entries. `--ago N` and `--days-ago N` remain accepted as compatibility aliases, but `--days N` is the preferred relative-day spelling. Use `mp calendar` when you want to inspect what `today`, `yesterday`, `this-week`, and `last-week` mean on the current local machine clock. The date filter is explicit by design. Broader natural-language lookup such as arbitrary `어제` / `지난주` phrasing remains a later search/review phase.
+`--limit N` can be combined with one date/window selector; the limit is applied after matching, keeping the most recent matching entries. `--ago N` and `--days-ago N` remain accepted as compatibility aliases, but `--days N` is the preferred relative-day spelling. Use `mp calendar` when you want to inspect what `today`, `yesterday`, `this-week`, and `last-week` mean on the current local machine clock. The date filter is explicit by design. A small deterministic Korean review alias layer accepts common phrases such as `mp 오늘 복기`, `mp 어제 복기`, `mp 이번주 복기`, and `mp 지난주 리뷰`; broader natural-language review remains out of scope.
 
 
 ## OMX/Codex aliases
 
 When the Codex/OMX skill adapter is installed, you can use readable `$mp-*`
-aliases inside Codex/OMX sessions without changing the standalone shell CLI:
+aliases and canonical `$mp ...` subcommands inside Codex/OMX sessions without
+changing the standalone shell CLI:
 
 ```text
 $mp-now
+$mp watch
+$mp fomo
 $mp-week
 $mp-calendar
 $mp-regime
@@ -262,6 +347,8 @@ $mp-find "금리" --this-week
 These aliases are thin wrappers around the same local `mp` binary:
 
 - `$mp-now` -> `mp now`
+- `$mp watch` -> `mp watch`
+- `$mp fomo` -> `mp fomo`
 - `$mp-week` -> `mp week`
 - `$mp-calendar` -> `mp calendar`
 - `$mp-regime` -> `mp regime`
@@ -271,10 +358,11 @@ These aliases are thin wrappers around the same local `mp` binary:
 - `$mp-review` -> `mp review`, `mp review --date YYYY-MM-DD`, `mp review --days N`, or a small period alias such as `mp review --this-week`
 - `$mp-find` -> `mp find`, optionally with the same small date/window selectors
 
-The canonical `$mp ...` skill remains available for flexible calls. The aliases
-are explicit only: they do not auto-capture arbitrary market/economy sentences,
-and live/source-backed lookup still requires `$mp-research` or an existing
-`mp ... --research` flow.
+The canonical `$mp ...` skill remains available for flexible calls and passes
+Korean/ticker text through to the CLI's deterministic alias router. The named
+`$mp-*` aliases are explicit wrappers, and live/source-backed lookup still
+requires `$mp-research`, an existing `mp ... --research` flow, or an evidence
+marker that the CLI router recognizes.
 
 ## Storage
 

--- a/adapters/claude-command/mp/COMMAND.md
+++ b/adapters/claude-command/mp/COMMAND.md
@@ -1,6 +1,6 @@
 ---
 name: mp
-description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, 주간 학습 카드, 날짜 창 확인, 로컬 저널 recall 검색, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp week, /mp calendar, /mp regime, /mp think, /mp review, /mp find 또는 오늘 시황/시장 펄스/시장 생각 피드백 요청에 사용합니다.
+description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색, 리서치 스캐폴드, 시장 카드, Daily Radar/FOMO 체크포인트, 주간 학습 카드, 날짜 창 확인, 로컬 저널 recall 검색, 사용자 해석 피드백, 리뷰를 제공합니다. /mp 질문, /mp ask 질문, /mp research 질문, /mp now, /mp watch, /mp fomo, /mp week, /mp calendar, /mp regime, /mp think, /mp review, /mp find 또는 오늘 시황/시장 펄스/이번주 복기/전에 금리 찾아줘/NVDA 리서치/포모/시장 생각 피드백 요청에 사용합니다.
 ---
 
 # market-pulse Claude Command
@@ -13,7 +13,14 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 /mp 금리가 내려간 게 진짜 완화 기대 때문임?
 /mp ask 대형 IPO 때문에 성장주가 강한 걸까?
 /mp research 금리 하락이 성장주에 좋은 신호임?
+/mp 오늘 시황
+/mp NVDA
+/mp NVDA 리서치
+/mp 전에 금리 찾아줘 --limit 3
+/mp 이번주 복기
 /mp now
+/mp watch
+/mp fomo
 /mp week
 /mp calendar
 /mp regime
@@ -31,12 +38,20 @@ description: market-pulse CLI를 실행해 터미널 기반 시장 질문 탐색
 
 1. 사용자의 인자를 파악합니다.
    - 없음 또는 `now`: `mp now` 실행
+   - `watch`: `mp watch` 실행
+   - `fomo`: `mp fomo` 실행
    - `week`: `mp week` 실행
    - `calendar` 또는 `cal`: `mp calendar` 실행
    - `regime`: `mp regime` 실행
    - `ask <question>`: `mp ask "<question>"` 실행
    - `research <question>`: `mp research "<question>"` 실행
-   - 알려진 명령어가 아닌 일반 텍스트: `mp "<question>"` 실행
+   - 알려진 명령어가 아닌 일반 텍스트: 그대로 `mp`에 전달해 CLI의 deterministic natural alias router가 처리하게 둠
+     - 예: `오늘 시황`, `시장 펄스`: 현재 시장 카드
+     - 예: `NVDA`, `비트코인`: safe inquiry scaffold
+     - 예: `NVDA 리서치`, `반도체 왜 오름?`: research intent routing
+     - 예: `오늘 복기`, `지난주 리뷰`: review selector routing
+     - 예: `전에 금리 찾아줘`: find routing
+     - 예: `내 생각 ...`, `메모 ...`: think routing
    - `think <text>`: `mp think "<text>"` 실행
    - `review`: `mp review` 실행
    - `review --date YYYY-MM-DD`: `mp review --date YYYY-MM-DD` 실행
@@ -58,8 +73,10 @@ cargo install --path . --force
 - 매수/매도 추천, 목표가, 손절가, 포트폴리오 지시는 하지 않습니다.
 - 투자 조언이 아니라 시장 문해력과 사고 훈련으로 프레이밍합니다.
 - 선호 구조: question breakdown, possible explanations, evidence to check, counter-view, next better question.
+- `watch` / `fomo`는 terminal-only Daily Radar와 FOMO decision-hygiene 체크포인트로 유지하고, 외부 알림/메신저/거래 지시를 프롬프트에서 추가하지 않습니다.
 - research 모드에서는 source metadata/no-provider fallback과 source-backed vs inference 구분을 유지합니다.
 - `MARKET_PULSE_SEARCH_CMD`가 설정되어 있으면 로컬 CLI가 외부 source metadata를 받아오며, command adapter는 그 경계를 보존합니다.
+- 자연어/티커 처리는 CLI의 작은 deterministic alias layer로만 취급하고, slash command 프롬프트에서 별도 분류기를 만들지 않습니다.
 - 피할 것: 자극적 헤드라인, 숫자만 나열, 단일 정답처럼 말하기.
 
 ## Examples
@@ -88,6 +105,22 @@ mp research "금리 하락이 성장주에 좋은 신호임?"
 mp now
 ```
 
+### `/mp watch`
+
+```bash
+mp watch
+```
+
+Daily Radar: 오늘 볼 scenario/watch/confirm/falsify와 FOMO 질문을 터미널에 출력하고, `--no-save`가 없으면 `radar` JSONL 이벤트로 저장합니다.
+
+### `/mp fomo`
+
+```bash
+mp fomo
+```
+
+FOMO Checkpoint: 최신 radar/pulse 문맥을 가져와 “증거인지, 기회비용 공포인지”를 분리하는 pause card를 출력하고, `--no-save`가 없으면 `fomo_check` JSONL 이벤트로 저장합니다.
+
 ### `/mp week`
 
 ```bash
@@ -99,6 +132,8 @@ mp week
 ```bash
 mp calendar
 ```
+
+로컬 리뷰 날짜창과 함께 US equities(NYSE/Nasdaq) / Korea equities(KRX/KOSPI)의 static regular-session 문맥, `mp now` / `mp week` close-basis 해석 브릿지를 보여줍니다. 첫 버전은 full holiday/early-close DB나 live event calendar가 아니라는 경계를 유지합니다.
 
 ### `/mp regime`
 

--- a/adapters/codex-skill/SKILL.md
+++ b/adapters/codex-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mp
-description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, weekly learning, calendar windows, local journal recall, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp week, mp calendar, mp regime, mp think, mp review, mp find, 오늘 시황, 시장 펄스, or asks for market-thinking feedback."
-argument-hint: "[question]|ask [question]|research [question]|now|week|calendar|regime|think|review [selector]|find [query]"
+description: "Run market-pulse CLI commands for terminal-native market inquiry, research-backed inquiry scaffolds, market context, daily radar/FOMO checkpoints, weekly learning, calendar windows, local journal recall, user-thought feedback, and review. Use when the user says $mp, mp <question>, mp ask, mp research, mp now, mp watch, mp fomo, mp week, mp calendar, mp regime, mp think, mp review, mp find, 오늘 시황, 시장 펄스, 이번주 복기, 전에 금리 찾아줘, NVDA 리서치, 포모, or asks for market-thinking feedback."
+argument-hint: "[question]|ask [question]|research [question]|now|watch|fomo|week|calendar|regime|think|review [selector]|find [query]"
 ---
 
 Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in the prompt.
@@ -9,10 +9,18 @@ Use the local `mp` CLI. Keep this skill thin: do not reimplement market-pulse in
 ## Commands
 
 - `$mp <question>` -> run `mp "<question>"`
+- `$mp 오늘 시황` / `$mp 시장 펄스` -> pass through to `mp` for deterministic natural routing
+- `$mp NVDA` / `$mp 비트코인` -> pass through to the safe inquiry scaffold
+- `$mp NVDA 리서치` / `$mp 반도체 왜 오름?` -> pass through to research intent routing
+- `$mp 오늘 복기` / `$mp 지난주 리뷰` -> pass through to review selector routing
+- `$mp 전에 금리 찾아줘` -> pass through to find routing
+- `$mp 내 생각 ...` / `$mp 메모 ...` -> pass through to think routing
 - `$mp ask <question>` -> run `mp ask "<question>"`
 - `$mp research <question>` -> run `mp research "<question>"`
 - `$mp <question> --research` -> run `mp "<question>" --research`
 - `$mp now` -> run `mp now`
+- `$mp watch` -> run `mp watch`
+- `$mp fomo` -> run `mp fomo`
 - `$mp week` -> run `mp week`
 - `$mp calendar` -> run `mp calendar`
 - `$mp regime` -> run `mp regime`
@@ -42,8 +50,10 @@ If the user invokes `$mp` without arguments, treat it as `$mp now`.
 - Never provide direct buy/sell recommendations, price targets, stop-loss, or portfolio instructions.
 - Frame output as market literacy and reasoning practice.
 - Prefer: question breakdown, possible explanations, evidence checks, counter-views, next better questions.
+- For `watch` / `fomo`, preserve the terminal-only daily radar and decision-hygiene framing; do not add external notifications or trading instructions in the prompt.
 - In research mode, preserve source metadata/no-provider fallback and distinguish source-backed material from inference scaffolding.
 - If `MARKET_PULSE_SEARCH_CMD` is configured, let `mp` use it as the restricted JSONL source bridge; do not reimplement search in the skill prompt.
+- Keep natural Korean/ticker handling as a deterministic CLI alias layer; pass text to `mp` rather than classifying it in this prompt.
 - Avoid: sensational headlines, numbers-only dashboards, false certainty.
 
 ## Fallback

--- a/adapters/codex-skill/aliases/mp-calendar/SKILL.md
+++ b/adapters/codex-skill/aliases/mp-calendar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mp-calendar
-description: "Run market-pulse calendar mode for local date windows and review shortcuts. Use when the user says $mp-calendar or wants to inspect today/yesterday/this-week/last-week review windows."
+description: "Run market-pulse calendar mode for a compact market-calendar report with local review windows, static US/Korea equity-session context, and mp now/week interpretation hints. Use when the user says $mp-calendar or wants to inspect today/yesterday/this-week/last-week review windows plus market session context."
 argument-hint: ""
 ---
 
@@ -10,7 +10,7 @@ Use the local `mp` CLI. Keep this alias thin: do not reimplement market-pulse in
 
 - `$mp-calendar` -> run `mp calendar`
 
-This alias takes no required argument. It prints local-date windows and the matching `mp review` shortcut commands. If extra market text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
+This alias takes no required argument. It prints local-date windows, static US/Korea equity-session context, a compact `mp now` / `mp week` pulse bridge, and the matching `mp review` shortcut commands. If extra market text is provided, prefer `$mp-ask` or `$mp-research` instead of guessing.
 
 ## Example CLI call
 
@@ -34,7 +34,7 @@ SOURCE: Keep this block textually consistent with `/Users/veluga/.codex/skills/m
 - Do not auto-capture arbitrary market/economy sentences; only run this alias when explicitly invoked.
 - Do not make live/API search automatic. Research/source lookup remains explicit through `$mp-research` or existing `mp ... --research` flows.
 - Do not add trading advice or portfolio guidance.
-- Do not treat local date windows as exchange-holiday calendars, trading signals, or market session proof.
+- Do not treat the static MVP as a full official exchange-holiday/early-close calendar, live event calendar, trading signal, or market session proof.
 
 ## Fallback
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -35,15 +35,57 @@ Acceptance criteria:
 - Saves a `research_inquiry` journal event with provider/source metadata unless `--no-save` is passed.
 - Avoids trading advice, buy/sell recommendations, price targets, stop-loss, and portfolio instructions.
 
+### Natural Korean/ticker input router
+
+Acceptance criteria:
+
+- Runs only after explicit command/help/option routing, so existing subcommands remain authoritative.
+- Preserves payload-bearing `Inquiry` and `Research` commands while using normalized command-shaped args for `Review`, `Find`, and `Think`.
+- Routes current-market aliases such as `오늘 시황`, `지금 시장`, and `시장 펄스` to `mp now`.
+- Routes period/context aliases such as `이번주`, `주간`, `레짐`, `국면`, and `캘린더` to the existing week/regime/calendar modes.
+- Routes common review phrases to existing selectors: `오늘 복기`, `어제 복기`, `이번주 복기`, and `지난주 리뷰`.
+- Routes recall phrases with remaining query text, such as `전에 금리 찾아줘`, to `mp find`.
+- Routes thought/journal phrases with remaining text, such as `내 생각 ...` and `메모 ...`, to `mp think`.
+- Routes explicit evidence/source intent such as `리서치`, `근거`, `출처`, `왜`, `확인`, `뉴스`, `자료`, `팩트체크`, or `--research` to research-backed inquiry.
+- Keeps ticker/company/asset-like text such as `NVDA`, `BTC`, `비트코인`, `삼성전자`, and `반도체` in the safe inquiry scaffold unless evidence/source intent is present.
+- Documents the feature as deterministic alias routing, not full natural-language understanding.
+- Does not add dependencies, MCP integration, live provider changes, ticker detail screens, or trading advice.
+
 ### `mp now`
 
 Acceptance criteria:
 
 - Prints a compact market card.
 - Includes mood, explicit quote/change basis, assets, drivers, tensions, question seeds / market puzzle prompts, and concept.
+- Adds `Semis` (`^SOX`) to non-compact `mp now` as a pulse-only semiconductor index proxy; `mp week` and `mp regime` do not inherit it in this phase.
+- In non-compact output, includes one six-line Daily Decision Checklist with Scenario, Confirm, Falsify, Watch, Discipline, and Journal lines.
+- Renders the checklist as a market-literacy observation/journaling routine, not investment advice or trade instruction.
+- Uses semis-led checklist wording only when `^SOX` data is available; otherwise falls back to non-semis wording.
+- Preserves `mp now --compact` as a one-line output with no checklist section.
 - Uses a close-to-close basis by default: local timestamp/session label plus latest Yahoo daily close value vs prior daily close from `range=5d&interval=1d`, with `regularMarketPrice` as fallback only; this is not a high/low gap, exact 24-hour, local calendar-day, or weekly return view.
 - Saves a `pulse` journal event unless `--no-save` is passed.
 - Does not block the loop if live quote fetch fails.
+
+### `mp watch`
+
+Acceptance criteria:
+
+- Prints a Daily Radar card for same-day market context, distinct from `mp now` but derived from the same cross-asset pulse/checklist logic.
+- Includes mood, basis, scenario, watch, confirm, falsify, compact drivers/tensions, and FOMO checkpoint prompts.
+- Saves a `radar` journal event unless `--no-save` is passed.
+- The `radar` event includes timestamp, linked pulse timestamp, mood, scenario, confirm, falsify, watch, and prompt fields.
+- Avoids trading advice, external messaging, OS push, daemon/launchd, paid API, and GUI requirements in this MVP.
+
+### `mp fomo`
+
+Acceptance criteria:
+
+- Prints a FOMO Checkpoint card for moments when the user wants to pause and separate evidence from opportunity-cost fear.
+- Links to the latest saved `radar` and `pulse` timestamps when available.
+- Carries forward the latest scenario/confirm/falsify/watch context when a prior radar exists.
+- Falls back gracefully when no radar exists and suggests `mp watch` for fresh context.
+- Saves a `fomo_check` journal event unless `--no-save` is passed.
+- Avoids trading advice, external messaging, OS push, daemon/launchd, paid API, and GUI requirements in this MVP.
 
 ### `mp week`
 
@@ -60,9 +102,12 @@ Acceptance criteria:
 
 Acceptance criteria:
 
-- Prints local-date windows for `today`, `yesterday`, `this-week`, and `last-week`.
+- Prints a compact market-calendar report, not only local date shortcuts.
+- Preserves local-date windows for `today`, `yesterday`, `this-week`, and `last-week`.
+- Shows static exchange-session context for US equities (NYSE/Nasdaq, 09:30-16:00 ET) and Korea equities (KRX/KOSPI, 09:00-15:30 KST).
+- Includes a calendar-to-pulse bridge explaining that `mp now` is close-to-close daily context and `mp week` combines the local journal week with the first matching Yahoo daily close.
 - Shows the matching `mp review` shortcut commands.
-- Names the boundary that these windows are local-date helpers, not exchange-holiday calendars or trading signals.
+- Names the boundary that this is a static MVP, not a full official holiday/early-close calendar, live event calendar, or trading signal.
 - Does not save a journal event.
 
 ### `mp regime`
@@ -91,8 +136,9 @@ Acceptance criteria:
 - Searches local JSONL journal entries by explicit query.
 - Supports `--date YYYY-MM-DD`, `--days N`, `--today`, `--yesterday`, `--this-week`, `--last-week`, and `--limit N`.
 - Uses the same single-selector conflict rule as `mp review`.
-- Renders a recall card with query, filter basis, matching entries, matched event counts, recurring themes, next recall question, and a local-journal-only boundary.
+- Renders a recall card with query, filter basis, matching entries, matched event counts including `radar` / `fomo_check`, recurring themes, next recall question, and a local-journal-only boundary.
 - Shows a helpful empty result when no entries match.
+- Accepts small deterministic Korean recall aliases only when query text remains.
 - Avoids fuzzy natural-language date parsing, exchange calendars, live provider changes, semantic/vector search, and trading advice.
 
 ### `mp review`
@@ -105,9 +151,11 @@ Acceptance criteria:
 - Supports small calendar aliases: `--today`, `--yesterday`, `--this-week`, and `--last-week`.
 - Rejects multiple date/window selectors in the same review command.
 - Applies `--limit N` after date/window matching when combined with a selector, keeping the most recent matching entries.
+- Counts `radar` and `fomo_check` events alongside existing pulse/week/regime/inquiry/research/thought/feedback counts.
 - Shows a distinct empty-date or empty-period message when no entries match the requested selector.
 - Surfaces repeated themes, concepts, inquiry counts, and question/thesis habits.
 - Suggests one reasoning drill.
+- Accepts small deterministic Korean review aliases for today, yesterday, this week, and last week.
 
 ## Install target
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,28 @@ struct Pulse {
 }
 
 #[derive(Clone, Debug)]
+struct DailyDecisionChecklist {
+    scenario: &'static str,
+    confirm: &'static str,
+    falsify: &'static str,
+    watch: &'static str,
+    discipline: &'static str,
+    journal: &'static str,
+}
+
+#[derive(Clone, Debug)]
+struct FomoCheckpoint {
+    timestamp: String,
+    linked_pulse: Option<String>,
+    linked_radar: Option<String>,
+    scenario: Option<String>,
+    confirm: Option<String>,
+    falsify: Option<String>,
+    watch: Option<String>,
+    prompt: String,
+}
+
+#[derive(Clone, Debug)]
 struct Regime {
     timestamp: String,
     basis: Vec<String>,
@@ -183,6 +205,8 @@ struct Feedback {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum CommandKind {
     Now,
+    Watch,
+    Fomo,
     Week,
     Calendar,
     Regime,
@@ -192,6 +216,12 @@ enum CommandKind {
     Help,
     Inquiry { text: String, no_save: bool },
     Research { text: String, no_save: bool },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ParsedCommand {
+    kind: CommandKind,
+    args: Vec<String>,
 }
 
 const PULSE_QUOTE_BASIS: &[&str] = &[
@@ -218,6 +248,11 @@ const SYMBOLS: &[(&str, &str, &str)] = &[
     ("BTC-USD", "BTC", "USD"),
 ];
 
+const PULSE_ONLY_SYMBOLS: &[(&str, &str, &str)] = &[("^SOX", "Semis", "")];
+
+const FOMO_JOURNAL_PROMPT: &str =
+    "Run `mp think` with one claim, one confirming signal, and one falsifier.";
+
 pub fn main_entry() {
     if let Err(err) = run(env::args().skip(1).collect()) {
         eprintln!("mp: {err}");
@@ -226,14 +261,17 @@ pub fn main_entry() {
 }
 
 fn run(args: Vec<String>) -> Result<(), String> {
-    match parse_command(&args)? {
-        CommandKind::Now => now(&args),
-        CommandKind::Week => week(&args),
-        CommandKind::Calendar => calendar(&args),
-        CommandKind::Regime => regime(&args),
-        CommandKind::Think => think(&args),
-        CommandKind::Review => review(&args),
-        CommandKind::Find => find(&args),
+    let parsed = parse_command_args(&args)?;
+    match parsed.kind {
+        CommandKind::Now => now(&parsed.args),
+        CommandKind::Watch => watch(&parsed.args),
+        CommandKind::Fomo => fomo(&parsed.args),
+        CommandKind::Week => week(&parsed.args),
+        CommandKind::Calendar => calendar(&parsed.args),
+        CommandKind::Regime => regime(&parsed.args),
+        CommandKind::Think => think(&parsed.args),
+        CommandKind::Review => review(&parsed.args),
+        CommandKind::Find => find(&parsed.args),
         CommandKind::Help => {
             print_help();
             Ok(())
@@ -243,22 +281,290 @@ fn run(args: Vec<String>) -> Result<(), String> {
     }
 }
 
+#[cfg(test)]
 fn parse_command(args: &[String]) -> Result<CommandKind, String> {
+    parse_command_args(args).map(|parsed| parsed.kind)
+}
+
+fn parse_command_args(args: &[String]) -> Result<ParsedCommand, String> {
     match args.first().map(String::as_str) {
-        None => Ok(CommandKind::Now),
-        Some("now") => Ok(CommandKind::Now),
-        Some("week") | Some("weekly") => Ok(CommandKind::Week),
-        Some("calendar") | Some("cal") => Ok(CommandKind::Calendar),
-        Some("regime") => Ok(CommandKind::Regime),
-        Some("think") => Ok(CommandKind::Think),
-        Some("review") => Ok(CommandKind::Review),
-        Some("find") | Some("search") => Ok(CommandKind::Find),
-        Some("help") | Some("--help") | Some("-h") => Ok(CommandKind::Help),
-        Some("ask") => inquiry_command(&args[1..], "`mp ask` needs a question"),
-        Some("research") => research_command(&args[1..], "`mp research` needs a question"),
+        None => Ok(parsed(CommandKind::Now, args)),
+        Some("now") => Ok(parsed(CommandKind::Now, args)),
+        Some("watch") => Ok(parsed(CommandKind::Watch, args)),
+        Some("fomo") => Ok(parsed(CommandKind::Fomo, args)),
+        Some("week") | Some("weekly") => Ok(parsed(CommandKind::Week, args)),
+        Some("calendar") | Some("cal") => Ok(parsed(CommandKind::Calendar, args)),
+        Some("regime") => Ok(parsed(CommandKind::Regime, args)),
+        Some("think") => Ok(parsed(CommandKind::Think, args)),
+        Some("review") => Ok(parsed(CommandKind::Review, args)),
+        Some("find") | Some("search") => Ok(parsed(CommandKind::Find, args)),
+        Some("help") | Some("--help") | Some("-h") => Ok(parsed(CommandKind::Help, args)),
+        Some("ask") => Ok(parsed(
+            inquiry_command(&args[1..], "`mp ask` needs a question")?,
+            args,
+        )),
+        Some("research") => Ok(parsed(
+            research_command(&args[1..], "`mp research` needs a question")?,
+            args,
+        )),
+        Some("--research") => Ok(parsed(
+            research_command(args, "`mp --research` needs a question")?,
+            args,
+        )),
         Some(first) if first.starts_with('-') => Err(format!("unknown option '{first}'")),
-        Some(_) => inquiry_command(args, "`mp` needs a market question"),
+        Some(_) if args.iter().any(|arg| arg == "--research") => Ok(parsed(
+            inquiry_command(args, "`mp` needs a market question")?,
+            args,
+        )),
+        Some(_) => natural_command(args).unwrap_or_else(|| {
+            inquiry_command(args, "`mp` needs a market question").map(|kind| parsed(kind, args))
+        }),
     }
+}
+
+fn parsed(kind: CommandKind, args: &[String]) -> ParsedCommand {
+    ParsedCommand {
+        kind,
+        args: args.to_vec(),
+    }
+}
+
+fn parsed_with_args(kind: CommandKind, args: Vec<String>) -> ParsedCommand {
+    ParsedCommand { kind, args }
+}
+
+fn natural_command(args: &[String]) -> Option<Result<ParsedCommand, String>> {
+    if let Some(parsed) = natural_review_command(args) {
+        return Some(Ok(parsed));
+    }
+    if let Some(parsed) = natural_find_command(args) {
+        return Some(Ok(parsed));
+    }
+    if let Some(parsed) = natural_think_command(args) {
+        return Some(Ok(parsed));
+    }
+    if has_research_intent(args) {
+        return Some(
+            research_command(args, "`mp` needs a market question").map(|kind| parsed(kind, args)),
+        );
+    }
+    if is_natural_now(args) {
+        return Some(Ok(parsed(CommandKind::Now, args)));
+    }
+    if is_natural_week(args) {
+        return Some(Ok(parsed(CommandKind::Week, args)));
+    }
+    if is_natural_regime(args) {
+        return Some(Ok(parsed(CommandKind::Regime, args)));
+    }
+    if is_natural_calendar(args) {
+        return Some(Ok(parsed(CommandKind::Calendar, args)));
+    }
+    None
+}
+
+fn natural_review_command(args: &[String]) -> Option<ParsedCommand> {
+    let (tokens, passthrough) = natural_tokens_and_flags(args, FlagPolicy::ReviewOrFind);
+    if !tokens
+        .iter()
+        .any(|token| token.contains("복기") || token.contains("리뷰"))
+    {
+        return None;
+    }
+
+    let alias = review_alias_from_tokens(&tokens)?;
+    let mut normalized = vec!["review".to_string(), alias.to_string()];
+    normalized.extend(passthrough);
+    Some(parsed_with_args(CommandKind::Review, normalized))
+}
+
+fn natural_find_command(args: &[String]) -> Option<ParsedCommand> {
+    let (tokens, passthrough) = natural_tokens_and_flags(args, FlagPolicy::ReviewOrFind);
+    if !tokens.iter().any(|token| {
+        token.contains("찾")
+            || token.contains("검색")
+            || matches!(token.as_str(), "전에" | "지난번" | "기억")
+    }) {
+        return None;
+    }
+
+    let query = tokens
+        .into_iter()
+        .filter(|token| !is_find_route_word(token))
+        .collect::<Vec<_>>();
+    if query.is_empty() {
+        return None;
+    }
+
+    let mut normalized = vec!["find".to_string()];
+    normalized.extend(query);
+    normalized.extend(passthrough);
+    Some(parsed_with_args(CommandKind::Find, normalized))
+}
+
+fn natural_think_command(args: &[String]) -> Option<ParsedCommand> {
+    let (tokens, passthrough) = natural_tokens_and_flags(args, FlagPolicy::Think);
+    if !tokens.iter().any(|token| {
+        matches!(token.as_str(), "생각" | "메모" | "기록" | "판단") || token.starts_with("생각:")
+    }) {
+        return None;
+    }
+
+    let thought = tokens
+        .into_iter()
+        .flat_map(|token| think_text_parts(&token))
+        .collect::<Vec<_>>();
+    if thought.is_empty() {
+        return None;
+    }
+
+    let mut normalized = vec!["think".to_string()];
+    normalized.extend(thought);
+    normalized.extend(passthrough);
+    Some(parsed_with_args(CommandKind::Think, normalized))
+}
+
+fn review_alias_from_tokens(tokens: &[String]) -> Option<&'static str> {
+    if tokens.iter().any(|token| token.contains("지난주")) {
+        return Some("--last-week");
+    }
+    if tokens
+        .iter()
+        .any(|token| token.contains("이번주") || token.contains("주간"))
+    {
+        return Some("--this-week");
+    }
+    if tokens.iter().any(|token| token.contains("어제")) {
+        return Some("--yesterday");
+    }
+    if tokens.iter().any(|token| token.contains("오늘")) {
+        return Some("--today");
+    }
+    None
+}
+
+fn is_find_route_word(token: &str) -> bool {
+    token.contains("찾")
+        || token.contains("검색")
+        || matches!(token, "전에" | "지난번" | "기억" | "내용")
+}
+
+fn think_text_parts(token: &str) -> Vec<String> {
+    match token {
+        "내" | "생각" | "메모" | "기록" | "판단" => Vec::new(),
+        token if token.starts_with("생각:") => {
+            let rest = token.trim_start_matches("생각:").trim();
+            if rest.is_empty() {
+                Vec::new()
+            } else {
+                vec![rest.to_string()]
+            }
+        }
+        _ => vec![token.to_string()],
+    }
+}
+
+fn has_research_intent(args: &[String]) -> bool {
+    let (tokens, _) = natural_tokens_and_flags(args, FlagPolicy::TextOnly);
+    tokens.iter().any(|token| {
+        token.contains("리서치")
+            || token.contains("근거")
+            || token.contains("출처")
+            || token.contains("왜")
+            || token.contains("확인")
+            || token.contains("뉴스")
+            || token.contains("자료")
+            || token.contains("팩트체크")
+    })
+}
+
+fn is_natural_now(args: &[String]) -> bool {
+    let (tokens, _) = natural_tokens_and_flags(args, FlagPolicy::TextOnly);
+    let snapshot_like = tokens.iter().any(|token| {
+        token.contains("시황")
+            || token.contains("시장")
+            || token.contains("마켓")
+            || token.contains("펄스")
+    });
+    tokens.len() <= 4 && snapshot_like
+}
+
+fn is_natural_week(args: &[String]) -> bool {
+    let (tokens, _) = natural_tokens_and_flags(args, FlagPolicy::TextOnly);
+    tokens
+        .iter()
+        .any(|token| token.contains("이번주") || token.contains("주간") || token.contains("한주"))
+}
+
+fn is_natural_regime(args: &[String]) -> bool {
+    let (tokens, _) = natural_tokens_and_flags(args, FlagPolicy::TextOnly);
+    tokens.iter().any(|token| {
+        token.contains("레짐")
+            || token.contains("국면")
+            || token.contains("1-3개월")
+            || token.contains("중기")
+    }) || (tokens.iter().any(|token| token.contains("흐름"))
+        && tokens
+            .iter()
+            .any(|token| token.contains("큰") || token.contains("중기")))
+}
+
+fn is_natural_calendar(args: &[String]) -> bool {
+    let (tokens, _) = natural_tokens_and_flags(args, FlagPolicy::TextOnly);
+    tokens.iter().any(|token| token.contains("캘린더"))
+}
+
+#[derive(Clone, Copy)]
+enum FlagPolicy {
+    TextOnly,
+    ReviewOrFind,
+    Think,
+}
+
+fn natural_tokens_and_flags(args: &[String], policy: FlagPolicy) -> (Vec<String>, Vec<String>) {
+    let mut tokens = Vec::new();
+    let mut passthrough = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if matches!(
+            arg.as_str(),
+            "--limit" | "--date" | "--days" | "--ago" | "--days-ago"
+        ) {
+            if matches!(policy, FlagPolicy::ReviewOrFind) {
+                passthrough.push(arg.clone());
+                if let Some(value) = args.get(i + 1) {
+                    passthrough.push(value.clone());
+                }
+            }
+            i += 2;
+            continue;
+        }
+        if matches!(
+            arg.as_str(),
+            "--today" | "--yesterday" | "--this-week" | "--last-week"
+        ) {
+            if matches!(policy, FlagPolicy::ReviewOrFind) {
+                passthrough.push(arg.clone());
+            }
+            i += 1;
+            continue;
+        }
+        if arg == "--no-save" {
+            if matches!(policy, FlagPolicy::Think) {
+                passthrough.push(arg.clone());
+            }
+            i += 1;
+            continue;
+        }
+        if arg.starts_with("--") {
+            i += 1;
+            continue;
+        }
+        tokens.push(arg.clone());
+        i += 1;
+    }
+    (tokens, passthrough)
 }
 
 fn inquiry_command(args: &[String], empty_error: &str) -> Result<CommandKind, String> {
@@ -296,7 +602,7 @@ fn collect_question_args(args: &[String]) -> (String, bool, bool) {
 
 fn print_help() {
     println!(
-        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp week [--no-save]\n  mp calendar\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]\n  mp find <query> [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]"
+        "Usage:\n  mp \"your market question\" [--no-save]\n  mp \"your market question\" --research [--no-save]\n  mp ask <your market question> [--no-save]\n  mp research <your market question> [--no-save]\n  mp now [--compact] [--no-save]\n  mp watch [--no-save]\n  mp fomo [--no-save]\n  mp week [--no-save]\n  mp calendar\n  mp regime [--no-save]\n  mp think <your market interpretation> [--no-save]\n  mp review [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]\n  mp find <query> [--limit N] [--date YYYY-MM-DD|--days N|--today|--yesterday|--this-week|--last-week]\n\nNatural aliases:\n  mp 오늘 시황\n  mp NVDA\n  mp NVDA 리서치\n  mp 전에 금리 찾아줘 --limit 3\n  mp 이번주 복기"
     );
 }
 
@@ -308,6 +614,27 @@ fn now(args: &[String]) -> Result<(), String> {
         append_event(&pulse_json(&pulse))?;
     }
     println!("{}", render_pulse(&pulse, compact));
+    Ok(())
+}
+
+fn watch(args: &[String]) -> Result<(), String> {
+    let no_save = args.iter().any(|a| a == "--no-save");
+    let pulse = build_pulse();
+    let checklist = daily_decision_checklist(&pulse);
+    if !no_save {
+        append_event(&radar_json(&pulse, &checklist))?;
+    }
+    println!("{}", render_radar(&pulse, &checklist));
+    Ok(())
+}
+
+fn fomo(args: &[String]) -> Result<(), String> {
+    let no_save = args.iter().any(|a| a == "--no-save");
+    let checkpoint = build_fomo_checkpoint();
+    if !no_save {
+        append_event(&fomo_check_json(&checkpoint))?;
+    }
+    println!("{}", render_fomo_checkpoint(&checkpoint));
     Ok(())
 }
 
@@ -821,7 +1148,7 @@ fn validate_review_date(date: &str) -> Result<(), String> {
 fn build_pulse() -> Pulse {
     let mut assets = Vec::new();
     let mut failures = 0;
-    for (symbol, label, unit) in SYMBOLS {
+    for &(symbol, label, unit) in SYMBOLS.iter().chain(PULSE_ONLY_SYMBOLS.iter()) {
         match fetch_asset(symbol, label, unit) {
             Ok(asset) => assets.push(asset),
             Err(_) => {
@@ -2106,12 +2433,217 @@ fn render_pulse(p: &Pulse, compact: bool) -> String {
     for seed in seeds {
         out.push_str(&format!("  - {seed}\n"));
     }
+    let checklist = daily_decision_checklist(p);
+    out.push_str(&render_daily_decision_checklist(&checklist));
     if !p.notes.is_empty() {
         out.push_str("\nSource notes\n");
         for n in &p.notes {
             out.push_str(&format!("  - {n}\n"));
         }
     }
+    out
+}
+
+fn daily_decision_checklist(p: &Pulse) -> DailyDecisionChecklist {
+    let nasdaq = change_for(&p.assets, "^IXIC");
+    let spx = change_for(&p.assets, "^GSPC");
+    let semis = change_for(&p.assets, "^SOX");
+    let kospi = change_for(&p.assets, "^KS11");
+    let usd_krw = change_for(&p.assets, "KRW=X");
+    let dxy = change_for(&p.assets, "DX-Y.NYB");
+    let rates = change_for(&p.assets, "^TNX");
+    let oil = change_for(&p.assets, "CL=F");
+    let btc = change_for(&p.assets, "BTC-USD");
+
+    let semis_available = semis.is_some();
+    let semis_positive = semis.is_some_and(|v| v > 0.75);
+    let semis_leading = semis.is_some_and(|v| v > 1.25)
+        && nasdaq.is_some_and(|v| v > 0.5)
+        && semis.unwrap_or(0.0) - spx.unwrap_or(0.0) >= 0.5;
+    let semis_weak = semis.is_some_and(|v| v < -0.5)
+        || (nasdaq.is_some_and(|v| v > 0.5) && semis.is_some_and(|v| v < 0.0));
+    let equity_positive = [nasdaq, spx, kospi]
+        .iter()
+        .flatten()
+        .any(|change| *change > 0.5);
+    let high_beta_positive = btc.is_some_and(|v| v > 1.0) || nasdaq.is_some_and(|v| v > 0.5);
+    let fx_pressure = dxy.is_some_and(|v| v > 0.25) || usd_krw.is_some_and(|v| v > 0.25);
+    let macro_pressure =
+        fx_pressure || rates.is_some_and(|v| v > 0.5) || oil.is_some_and(|v| v > 1.0);
+    let korea_strong = kospi.is_some_and(|v| v > 0.6);
+
+    let scenario = if semis_leading && macro_pressure {
+        "Semis-led growth risk-on; macro confirmation incomplete"
+    } else if semis_leading {
+        "Semis-led growth risk-on; watch BTC/KOSPI confirmation"
+    } else if semis_available && semis_weak {
+        "Growth leadership fading; watch whether semis or BTC breaks first"
+    } else if korea_strong && fx_pressure && semis_positive {
+        "Korea/EM beta confirmation needed despite semis strength"
+    } else if korea_strong && fx_pressure {
+        "Korea/EM beta confirmation needed"
+    } else if semis_available && nasdaq.is_some_and(|v| v > 0.5) && !semis_positive {
+        "Nasdaq risk-on with semis confirmation still pending"
+    } else if high_beta_positive && macro_pressure {
+        "High-beta risk-on attempt; macro confirmation incomplete"
+    } else if high_beta_positive || equity_positive {
+        "Broad risk-on attempt; watch dollar/rates confirmation"
+    } else if macro_pressure && nasdaq.is_some_and(|v| v > 0.0) {
+        "Macro pressure fighting growth leadership"
+    } else {
+        "Mixed tape; wait for confirmation rather than forcing a one-cause story"
+    };
+
+    let confirm = if semis_leading && macro_pressure {
+        "Semis and Nasdaq keep leading while BTC/KOSPI confirm and dollar/rates pressure stops rising."
+    } else if semis_leading {
+        "Semis and Nasdaq keep leading while BTC and KOSPI confirm the same risk tone."
+    } else if semis_available && semis_weak {
+        "Semis stabilize before Nasdaq, BTC, and KOSPI lose the same growth story."
+    } else if semis_available && nasdaq.is_some_and(|v| v > 0.5) && !semis_positive {
+        "Semis stop lagging while Nasdaq, BTC, and KOSPI keep confirming together."
+    } else if korea_strong && fx_pressure {
+        "KOSPI strength holds while USD/KRW and DXY stop adding pressure."
+    } else if high_beta_positive && macro_pressure {
+        "Equities and BTC keep confirming while dollar/rates pressure stops rising."
+    } else if high_beta_positive || equity_positive {
+        "Nasdaq, S&P 500, KOSPI, and BTC keep pointing in the same direction."
+    } else {
+        "At least two assets confirm the same story in the next check."
+    };
+
+    let falsify = if semis_available {
+        "Semis lose leadership first, or Nasdaq weakness pulls BTC/KOSPI lower while dollar or rates pressure rises."
+    } else if macro_pressure {
+        "Nasdaq weakness pulls BTC/KOSPI lower while dollar or rates pressure rises."
+    } else {
+        "The strongest index fades first and cross-asset confirmation disappears."
+    };
+
+    DailyDecisionChecklist {
+        scenario,
+        confirm,
+        falsify,
+        watch: if semis_available {
+            "Semis vs Nasdaq, BTC, KOSPI, DXY, USD/KRW, and US 10Y."
+        } else {
+            "Nasdaq vs S&P 500, BTC, DXY, USD/KRW, US 10Y, and KOSPI."
+        },
+        discipline: if semis_available {
+            "Treat laggards as unproven unless they hold during Nasdaq/semis weakness."
+        } else {
+            "Treat laggards as unproven unless they hold when Nasdaq weakens."
+        },
+        journal: if semis_available {
+            "Run `mp think` with one leadership claim, one confirming signal, and one falsifier."
+        } else {
+            "Run `mp think` with one claim, one confirming signal, and one falsifier."
+        },
+    }
+}
+
+fn render_daily_decision_checklist(checklist: &DailyDecisionChecklist) -> String {
+    format!(
+        "\nDaily Decision Checklist\n  Scenario: {}\n  Confirm: {}\n  Falsify: {}\n  Watch: {}\n  Discipline: {}\n  Journal: {}\n",
+        checklist.scenario,
+        checklist.confirm,
+        checklist.falsify,
+        checklist.watch,
+        checklist.discipline,
+        checklist.journal
+    )
+}
+
+fn render_radar(p: &Pulse, checklist: &DailyDecisionChecklist) -> String {
+    let mut out = format!(
+        "Market Radar · {} · {}\n\nMood\n  {}\n\nBasis\n",
+        p.timestamp, p.session, p.mood
+    );
+    for b in &p.basis {
+        out.push_str(&format!("  - {b}\n"));
+    }
+    out.push_str(&format!(
+        "\nRadar\n  Scenario: {}\n  Watch: {}\n  Confirm: {}\n  Falsify: {}\n",
+        checklist.scenario, checklist.watch, checklist.confirm, checklist.falsify
+    ));
+    if !p.drivers.is_empty() {
+        out.push_str("\nDrivers to explain, not chase\n");
+        for (i, d) in p.drivers.iter().take(3).enumerate() {
+            out.push_str(&format!("  {}. {d}\n", i + 1));
+        }
+    }
+    if !p.tensions.is_empty() {
+        out.push_str("\nTension\n");
+        for tension in p.tensions.iter().take(2) {
+            out.push_str(&format!("  - {tension}\n"));
+        }
+    }
+    out.push_str(
+        "\nFOMO checkpoint\n  - Am I reacting to evidence, or opportunity-cost fear?\n  - What single observation would make this story wrong today?\n  - What would I write in `mp think` if I had to defend the claim later?\n\nBoundary\n  Reasoning support only; no trading instructions.\n",
+    );
+    if !p.notes.is_empty() {
+        out.push_str("\nSource notes\n");
+        for n in &p.notes {
+            out.push_str(&format!("  - {n}\n"));
+        }
+    }
+    out
+}
+
+fn build_fomo_checkpoint() -> FomoCheckpoint {
+    let radar = latest_radar_event();
+    FomoCheckpoint {
+        timestamp: timestamp(),
+        linked_pulse: radar
+            .as_ref()
+            .and_then(|line| json_field(line, "linked_pulse_timestamp"))
+            .or_else(latest_pulse_timestamp),
+        linked_radar: radar
+            .as_ref()
+            .and_then(|line| json_field(line, "timestamp"))
+            .or_else(latest_radar_timestamp),
+        scenario: radar.as_ref().and_then(|line| json_field(line, "scenario")),
+        confirm: radar.as_ref().and_then(|line| json_field(line, "confirm")),
+        falsify: radar.as_ref().and_then(|line| json_field(line, "falsify")),
+        watch: radar.as_ref().and_then(|line| json_field(line, "watch")),
+        prompt: FOMO_JOURNAL_PROMPT.into(),
+    }
+}
+
+fn render_fomo_checkpoint(checkpoint: &FomoCheckpoint) -> String {
+    let latest_radar = checkpoint
+        .linked_radar
+        .as_deref()
+        .unwrap_or("not recorded yet");
+    let latest_pulse = checkpoint
+        .linked_pulse
+        .as_deref()
+        .unwrap_or("not recorded yet");
+    let scenario = checkpoint
+        .scenario
+        .as_deref()
+        .unwrap_or("no radar scenario yet; run `mp watch` for a fresh context card");
+
+    let mut out = format!(
+        "FOMO Checkpoint · {}\n\nContext\n  Latest radar: {}\n  Latest pulse: {}\n  Scenario: {}\n\nPause\n  1. What exactly am I reacting to?\n  2. Which evidence confirms the scenario?\n  3. Which observation would falsify it today?\n  4. Is this evidence, or opportunity-cost fear?\n",
+        checkpoint.timestamp, latest_radar, latest_pulse, scenario
+    );
+    if checkpoint.confirm.is_some() || checkpoint.falsify.is_some() || checkpoint.watch.is_some() {
+        out.push_str("\nCarry-over checks\n");
+        if let Some(watch) = checkpoint.watch.as_deref() {
+            out.push_str(&format!("  Watch: {watch}\n"));
+        }
+        if let Some(confirm) = checkpoint.confirm.as_deref() {
+            out.push_str(&format!("  Confirm: {confirm}\n"));
+        }
+        if let Some(falsify) = checkpoint.falsify.as_deref() {
+            out.push_str(&format!("  Falsify: {falsify}\n"));
+        }
+    }
+    out.push_str(&format!(
+        "\nNext journal prompt\n  {}\n\nBoundary\n  Reasoning support only; no trading instructions.\n",
+        checkpoint.prompt
+    ));
     out
 }
 
@@ -2427,11 +2959,45 @@ fn render_feedback(f: &Feedback) -> String {
     out
 }
 
+struct ExchangeSessionRow {
+    label: &'static str,
+    regular_hours: &'static str,
+    status: &'static str,
+    note: &'static str,
+}
+
+fn static_equity_session_status(weekday: Option<u32>) -> &'static str {
+    match weekday {
+        Some(1..=5) => "weekday under static MVP rules; holidays/early closes not modeled",
+        Some(6 | 7) => "weekend under static MVP rules; regular equity session closed",
+        _ => "status unavailable under static MVP rules",
+    }
+}
+
+fn exchange_session_rows(weekday: Option<u32>) -> [ExchangeSessionRow; 2] {
+    let status = static_equity_session_status(weekday);
+    [
+        ExchangeSessionRow {
+            label: "US equities (NYSE/Nasdaq, ET)",
+            regular_hours: "09:30-16:00 ET",
+            status,
+            note: "Korea-local date can differ from the US session date; use this as session context, not official open-now proof.",
+        },
+        ExchangeSessionRow {
+            label: "Korea equities (KRX/KOSPI, KST)",
+            regular_hours: "09:00-15:30 KST",
+            status,
+            note: "Holidays and early closes are not modeled in this first pass.",
+        },
+    ]
+}
+
 fn render_calendar() -> String {
     let today = date_for_days_ago(0).unwrap_or_else(|_| "unavailable".into());
     let yesterday = date_for_days_ago(1).unwrap_or_else(|_| "unavailable".into());
     let this_week = current_week_date_prefixes();
     let last_week = last_week_date_prefixes();
+    let weekday = iso_weekday();
     let mut out = format!(
         "Market Pulse Calendar · {}\n\nLocal date windows\n",
         timestamp()
@@ -2446,6 +3012,17 @@ fn render_calendar() -> String {
         "  - last-week: {}\n",
         week_window_label(&last_week)
     ));
+    out.push_str("\nExchange sessions (static MVP)\n");
+    for row in exchange_session_rows(weekday) {
+        out.push_str(&format!(
+            "  - {}: regular {}; {}\n",
+            row.label, row.regular_hours, row.status
+        ));
+        out.push_str(&format!("    note: {}\n", row.note));
+    }
+    out.push_str(
+        "\nCalendar ↔ pulse bridge\n  - mp now: close-to-close daily pulse; read it against latest available exchange closes, not only the local date.\n  - mp week: local journal week plus first matching Yahoo daily close in the current local week.\n  - US/Korea session dates can differ from the Korea local timestamp; this card gives interpretation context, not official exchange proof.\n",
+    );
     out.push_str(
         "\nReview shortcuts\n  - mp review --today\n  - mp review --yesterday\n  - mp review --this-week\n  - mp review --last-week\n",
     );
@@ -2453,7 +3030,7 @@ fn render_calendar() -> String {
         "\nHow market-pulse uses these windows\n  - mp week uses the current local calendar week for journal review.\n  - mp week prices the market window from the first Yahoo close matching the current local week when available.\n  - mp review period aliases filter journal timestamp dates; they are not fuzzy full-text search.\n",
     );
     out.push_str(
-        "\nBoundary\n  Calendar windows are local-date helpers for market literacy, not exchange-holiday calendars or trading signals.\n",
+        "\nBoundary\n  Static exchange-session MVP for market literacy; not a full official holiday/early-close calendar, live event calendar, or trading signal.\n",
     );
     out
 }
@@ -2564,11 +3141,27 @@ fn event_matches_date(line: &str, date: &str) -> bool {
 }
 
 fn latest_pulse_timestamp() -> Option<String> {
+    latest_event_timestamp("pulse")
+}
+
+fn latest_radar_timestamp() -> Option<String> {
+    latest_event_timestamp("radar")
+}
+
+fn latest_event_timestamp(event_type: &str) -> Option<String> {
+    latest_event(event_type).and_then(|l| json_field(&l, "timestamp"))
+}
+
+fn latest_radar_event() -> Option<String> {
+    latest_event("radar")
+}
+
+fn latest_event(event_type: &str) -> Option<String> {
+    let needle = format!("\"type\":\"{event_type}\"");
     read_events(usize::MAX)
         .into_iter()
         .rev()
-        .find(|l| l.contains("\"type\":\"pulse\""))
-        .and_then(|l| json_field(&l, "timestamp"))
+        .find(|l| l.contains(&needle))
 }
 
 fn json_field(line: &str, key: &str) -> Option<String> {
@@ -2704,9 +3297,11 @@ fn render_find_from_events(
 
     let summary = summarize_events(events);
     let mut out = format!(
-        "Market Pulse Find\n\nQuery: \"{query}\"\nFilter: {filter}\nJournal: {journal}\nEntries matched: {} · pulses {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nMatches\n",
+        "Market Pulse Find\n\nQuery: \"{query}\"\nFilter: {filter}\nJournal: {journal}\nEntries matched: {} · pulses {} · radars {} · fomo {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nMatches\n",
         events.len(),
         summary.pulses,
+        summary.radars,
+        summary.fomo_checks,
         summary.weeks,
         summary.regimes,
         summary.inquiries,
@@ -2748,6 +3343,10 @@ fn event_recall_snippet(line: &str, query: &str) -> String {
     let event_type = json_field(line, "type").unwrap_or_else(|| "entry".into());
     let body = json_field(line, "text")
         .or_else(|| json_field(line, "question"))
+        .or_else(|| json_field(line, "scenario"))
+        .or_else(|| json_field(line, "prompt"))
+        .or_else(|| json_field(line, "confirm"))
+        .or_else(|| json_field(line, "falsify"))
         .or_else(|| json_field(line, "mood"))
         .or_else(|| json_field(line, "concept"))
         .or_else(|| json_field(line, "source_titles"))
@@ -2775,6 +3374,8 @@ fn compact_snippet(text: &str, _query: &str) -> String {
 #[derive(Clone, Debug)]
 struct JournalSummary {
     pulses: usize,
+    radars: usize,
+    fomo_checks: usize,
     weeks: usize,
     regimes: usize,
     inquiries: usize,
@@ -2788,6 +3389,8 @@ struct JournalSummary {
 
 fn summarize_events(events: &[String]) -> JournalSummary {
     let pulses = count_events(events, "pulse");
+    let radars = count_events(events, "radar");
+    let fomo_checks = count_events(events, "fomo_check");
     let weeks = count_events(events, "week");
     let regimes = count_events(events, "regime");
     let inquiries = count_events(events, "inquiry");
@@ -2810,9 +3413,13 @@ fn summarize_events(events: &[String]) -> JournalSummary {
         l.contains("\"type\":\"thought\"")
             || l.contains("\"type\":\"inquiry\"")
             || l.contains("\"type\":\"research_inquiry\"")
+            || l.contains("\"type\":\"radar\"")
+            || l.contains("\"type\":\"fomo_check\"")
     }) {
         let text = json_field(line, "text")
             .or_else(|| json_field(line, "question"))
+            .or_else(|| json_field(line, "scenario"))
+            .or_else(|| json_field(line, "prompt"))
             .unwrap_or_default();
         if contains_hangul(&text) {
             korean_entries += 1;
@@ -2832,6 +3439,8 @@ fn summarize_events(events: &[String]) -> JournalSummary {
     thesis_types.dedup();
     JournalSummary {
         pulses,
+        radars,
+        fomo_checks,
         weeks,
         regimes,
         inquiries,
@@ -2854,7 +3463,7 @@ fn render_review_from_events(events: &[String], journal: &str) -> String {
         return "No market-pulse journal entries yet. Start with `mp \"your market question\"`, then `mp think \"...\"`.".into();
     }
     let summary = summarize_events(events);
-    let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), summary.pulses, summary.weeks, summary.regimes, summary.inquiries, summary.research_inquiries, summary.thoughts, summary.feedback);
+    let mut out = format!("Market Pulse Review\n\nJournal: {journal}\nEntries scanned: {} · pulses {} · radars {} · fomo {} · weeks {} · regimes {} · inquiries {} · research {} · thoughts {} · feedback {}\n\nRepeated themes\n", events.len(), summary.pulses, summary.radars, summary.fomo_checks, summary.weeks, summary.regimes, summary.inquiries, summary.research_inquiries, summary.thoughts, summary.feedback);
     let mut wrote = false;
     for (tag, count) in summary.tag_counts.iter().filter(|(_, c)| *c > 0).take(6) {
         wrote = true;
@@ -2884,6 +3493,32 @@ fn pulse_json(p: &Pulse) -> String {
         esc(&p.mood),
         esc(&p.question),
         esc(&p.concept)
+    )
+}
+
+fn radar_json(p: &Pulse, checklist: &DailyDecisionChecklist) -> String {
+    format!(
+        "{{\"type\":\"radar\",\"timestamp\":\"{}\",\"session\":\"{}\",\"linked_pulse_timestamp\":\"{}\",\"mood\":\"{}\",\"scenario\":\"{}\",\"confirm\":\"{}\",\"falsify\":\"{}\",\"watch\":\"{}\",\"prompt\":\"{}\"}}",
+        esc(&p.timestamp),
+        esc(&p.session),
+        esc(&p.timestamp),
+        esc(&p.mood),
+        esc(checklist.scenario),
+        esc(checklist.confirm),
+        esc(checklist.falsify),
+        esc(checklist.watch),
+        esc(FOMO_JOURNAL_PROMPT)
+    )
+}
+
+fn fomo_check_json(checkpoint: &FomoCheckpoint) -> String {
+    format!(
+        "{{\"type\":\"fomo_check\",\"timestamp\":\"{}\",\"linked_pulse_timestamp\":{},\"linked_radar_timestamp\":{},\"scenario\":\"{}\",\"prompt\":\"{}\"}}",
+        esc(&checkpoint.timestamp),
+        opt_json(checkpoint.linked_pulse.as_deref()),
+        opt_json(checkpoint.linked_radar.as_deref()),
+        esc(checkpoint.scenario.as_deref().unwrap_or("")),
+        esc(&checkpoint.prompt)
     )
 }
 
@@ -2997,6 +3632,10 @@ fn session() -> String {
 mod tests {
     use super::*;
 
+    fn args(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| (*part).to_string()).collect()
+    }
+
     #[test]
     fn routes_bare_question_and_ask_to_inquiry() {
         let bare = vec!["금리가".into(), "내려간".into(), "이유?".into()];
@@ -3031,6 +3670,18 @@ mod tests {
         assert_eq!(
             parse_command(&["regime".into(), "--no-save".into()]).unwrap(),
             CommandKind::Regime
+        );
+    }
+
+    #[test]
+    fn routes_watch_and_fomo_commands() {
+        assert_eq!(
+            parse_command(&["watch".into(), "--no-save".into()]).unwrap(),
+            CommandKind::Watch
+        );
+        assert_eq!(
+            parse_command(&["fomo".into(), "--no-save".into()]).unwrap(),
+            CommandKind::Fomo
         );
     }
 
@@ -3102,6 +3753,277 @@ mod tests {
             }
         );
         assert!(parse_command(&["research".into()]).is_err());
+    }
+
+    #[test]
+    fn routes_korean_market_pulse_aliases_to_now() {
+        assert_eq!(
+            parse_command(&args(&["오늘", "시황"])).unwrap(),
+            CommandKind::Now
+        );
+        assert_eq!(
+            parse_command(&args(&["지금", "시장"])).unwrap(),
+            CommandKind::Now
+        );
+        assert_eq!(
+            parse_command(&args(&["시장", "펄스"])).unwrap(),
+            CommandKind::Now
+        );
+    }
+
+    #[test]
+    fn routes_korean_period_and_regime_aliases() {
+        assert_eq!(
+            parse_command(&args(&["이번주"])).unwrap(),
+            CommandKind::Week
+        );
+        assert_eq!(
+            parse_command(&args(&["주간", "체크"])).unwrap(),
+            CommandKind::Week
+        );
+        assert_eq!(
+            parse_command(&args(&["레짐"])).unwrap(),
+            CommandKind::Regime
+        );
+        assert_eq!(
+            parse_command(&args(&["국면", "체크"])).unwrap(),
+            CommandKind::Regime
+        );
+        assert_eq!(
+            parse_command(&args(&["캘린더"])).unwrap(),
+            CommandKind::Calendar
+        );
+    }
+
+    #[test]
+    fn routes_korean_review_aliases_with_date_windows() {
+        assert_eq!(
+            parse_command_args(&args(&["오늘", "복기"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Review,
+                args: args(&["review", "--today"]),
+            }
+        );
+        assert_eq!(
+            parse_command_args(&args(&["어제", "복기"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Review,
+                args: args(&["review", "--yesterday"]),
+            }
+        );
+        assert_eq!(
+            parse_command_args(&args(&["이번주", "복기"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Review,
+                args: args(&["review", "--this-week"]),
+            }
+        );
+        assert_eq!(
+            parse_command_args(&args(&["지난주", "리뷰", "--limit", "3"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Review,
+                args: args(&["review", "--last-week", "--limit", "3"]),
+            }
+        );
+    }
+
+    #[test]
+    fn routes_korean_recall_aliases_to_find() {
+        assert_eq!(
+            parse_command_args(&args(&["전에", "금리", "찾아줘"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Find,
+                args: args(&["find", "금리"]),
+            }
+        );
+        assert_eq!(
+            parse_command_args(&args(&["지난번", "반도체", "검색", "--limit", "3"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Find,
+                args: args(&["find", "반도체", "--limit", "3"]),
+            }
+        );
+    }
+
+    #[test]
+    fn routes_korean_thought_aliases_to_think() {
+        assert_eq!(
+            parse_command_args(&args(&["내", "생각", "나스닥은", "너무", "오른듯"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Think,
+                args: args(&["think", "나스닥은", "너무", "오른듯"]),
+            }
+        );
+        assert_eq!(
+            parse_command_args(&args(&["메모", "달러가", "약한데", "코스피가", "강함"])).unwrap(),
+            ParsedCommand {
+                kind: CommandKind::Think,
+                args: args(&["think", "달러가", "약한데", "코스피가", "강함"]),
+            }
+        );
+    }
+
+    #[test]
+    fn routes_korean_research_intent_to_research() {
+        assert_eq!(
+            parse_command(&args(&["NVDA", "리서치"])).unwrap(),
+            CommandKind::Research {
+                text: "NVDA 리서치".into(),
+                no_save: false,
+            }
+        );
+        assert_eq!(
+            parse_command(&args(&["반도체", "왜", "오름?"])).unwrap(),
+            CommandKind::Research {
+                text: "반도체 왜 오름?".into(),
+                no_save: false,
+            }
+        );
+        assert_eq!(
+            parse_command(&args(&["삼성전자", "근거", "확인", "--no-save"])).unwrap(),
+            CommandKind::Research {
+                text: "삼성전자 근거 확인".into(),
+                no_save: true,
+            }
+        );
+    }
+
+    #[test]
+    fn routes_leading_research_flag_without_opening_unknown_options() {
+        assert_eq!(
+            parse_command(&args(&["--research", "NVDA"])).unwrap(),
+            CommandKind::Research {
+                text: "NVDA".into(),
+                no_save: false,
+            }
+        );
+        assert_eq!(
+            parse_command(&args(&["--research", "삼성전자", "--no-save"])).unwrap(),
+            CommandKind::Research {
+                text: "삼성전자".into(),
+                no_save: true,
+            }
+        );
+        assert!(parse_command(&args(&["--bad", "NVDA"]))
+            .unwrap_err()
+            .contains("unknown option '--bad'"));
+    }
+
+    #[test]
+    fn routes_ticker_company_asset_only_to_safe_inquiry() {
+        for asset in ["NVDA", "BTC", "비트코인", "삼성전자", "반도체"] {
+            assert_eq!(
+                parse_command(&args(&[asset])).unwrap(),
+                CommandKind::Inquiry {
+                    text: asset.into(),
+                    no_save: false,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn natural_router_preserves_precedence() {
+        assert!(matches!(
+            parse_command(&args(&["research", "오늘", "시황"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert_eq!(
+            parse_command(&args(&["ask", "NVDA", "리서치?"])).unwrap(),
+            CommandKind::Inquiry {
+                text: "NVDA 리서치?".into(),
+                no_save: false,
+            }
+        );
+        assert_eq!(
+            parse_command(&args(&["now", "리서치"])).unwrap(),
+            CommandKind::Now
+        );
+        assert_eq!(
+            parse_command(&args(&["오늘", "시황"])).unwrap(),
+            CommandKind::Now
+        );
+        assert!(matches!(
+            parse_command(&args(&["오늘", "시황", "근거"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert!(matches!(
+            parse_command(&args(&["오늘", "시황", "--research"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert!(matches!(
+            parse_command(&args(&["오늘", "복기", "--research"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert!(matches!(
+            parse_command(&args(&["전에", "금리", "찾아줘", "--research"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert_eq!(
+            parse_command(&args(&[
+                "내",
+                "생각",
+                "반도체가",
+                "시장",
+                "주도인지",
+                "확인"
+            ]))
+            .unwrap(),
+            CommandKind::Think
+        );
+        assert_eq!(
+            parse_command(&args(&["전에", "반도체", "확인한", "내용", "찾아줘"])).unwrap(),
+            CommandKind::Find
+        );
+        assert!(matches!(
+            parse_command(&args(&["내", "생각", "반도체", "확인", "--research"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert!(matches!(
+            parse_command(&args(&["--research", "NVDA"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+        assert!(parse_command(&args(&["--bad", "NVDA"])).is_err());
+        assert!(matches!(
+            parse_command(&args(&["NVDA"])).unwrap(),
+            CommandKind::Inquiry { .. }
+        ));
+        assert!(matches!(
+            parse_command(&args(&["NVDA", "리서치"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
+    }
+
+    #[test]
+    fn intent_markers_beat_generic_research_terms_unless_research_flagged() {
+        assert_eq!(
+            parse_command(&args(&[
+                "내",
+                "생각",
+                "반도체가",
+                "시장",
+                "주도인지",
+                "확인"
+            ]))
+            .unwrap(),
+            CommandKind::Think
+        );
+        assert_eq!(
+            parse_command(&args(&["메모", "달러", "움직임", "확인"])).unwrap(),
+            CommandKind::Think
+        );
+        assert_eq!(
+            parse_command(&args(&["전에", "반도체", "확인한", "내용", "찾아줘"])).unwrap(),
+            CommandKind::Find
+        );
+        assert_eq!(
+            parse_command(&args(&["오늘", "복기", "근거"])).unwrap(),
+            CommandKind::Review
+        );
+        assert!(matches!(
+            parse_command(&args(&["내", "생각", "반도체", "확인", "--research"])).unwrap(),
+            CommandKind::Research { .. }
+        ));
     }
 
     #[test]
@@ -3350,6 +4272,19 @@ mod tests {
     }
 
     #[test]
+    fn review_counts_radar_and_fomo_checkpoint_events() {
+        let events = vec![
+            "{\"type\":\"radar\",\"timestamp\":\"2026-04-23T09:00:00+0900\",\"scenario\":\"Semis-led growth risk-on; watch BTC/KOSPI confirmation\",\"confirm\":\"Semis and Nasdaq keep leading\",\"falsify\":\"Semis lose leadership first\",\"watch\":\"Semis vs Nasdaq\",\"prompt\":\"Run mp think\"}".into(),
+            "{\"type\":\"fomo_check\",\"timestamp\":\"2026-04-23T09:05:00+0900\",\"linked_radar_timestamp\":\"2026-04-23T09:00:00+0900\",\"scenario\":\"Semis-led growth risk-on; watch BTC/KOSPI confirmation\",\"prompt\":\"Run mp think\"}".into(),
+        ];
+        let out = render_review_from_events(&events, "/tmp/journal.jsonl");
+
+        assert!(out.contains("radars 1"));
+        assert!(out.contains("fomo 1"));
+        assert!(out.contains("semis"));
+    }
+
+    #[test]
     fn review_date_filter_keeps_only_matching_timestamp_date() {
         let events = vec![
             "{\"type\":\"inquiry\",\"timestamp\":\"2026-04-20T09:00:00+0900\",\"question\":\"달러가 코스피에 부담?\",\"thesis_type\":\"dollar-liquidity transmission thesis\",\"concepts\":\"dollar liquidity\"}".into(),
@@ -3439,12 +4374,73 @@ mod tests {
     fn calendar_renders_review_shortcuts_and_boundary() {
         let out = render_calendar();
         assert!(out.contains("Market Pulse Calendar"));
+        assert!(out.contains("Local date windows"));
         assert!(out.contains("today:"));
+        assert!(out.contains("yesterday:"));
         assert!(out.contains("this-week:"));
         assert!(out.contains("last-week:"));
+        assert!(out.contains("mp review --today"));
+        assert!(out.contains("mp review --yesterday"));
         assert!(out.contains("mp review --this-week"));
+        assert!(out.contains("mp review --last-week"));
         assert!(out.contains("not fuzzy full-text search"));
-        assert!(out.contains("not exchange-holiday calendars"));
+        assert!(out.contains("static MVP") || out.contains("Static exchange-session MVP"));
+        assert!(out.contains("not a full official holiday/early-close calendar"));
+        assert!(out.contains("not") && out.contains("trading signal"));
+    }
+
+    #[test]
+    fn calendar_renders_exchange_session_section() {
+        let out = render_calendar();
+        assert!(out.contains("Exchange sessions (static MVP)"));
+        assert!(out.contains("US equities"));
+        assert!(out.contains("NYSE/Nasdaq"));
+        assert!(out.contains("Korea equities"));
+        assert!(out.contains("KRX/KOSPI"));
+        assert!(out.contains("ET"));
+        assert!(out.contains("KST"));
+        assert!(out.contains("09:30-16:00 ET"));
+        assert!(out.contains("09:00-15:30 KST"));
+    }
+
+    #[test]
+    fn calendar_renders_pulse_bridge() {
+        let out = render_calendar();
+        assert!(out.contains("Calendar ↔ pulse bridge"));
+        assert!(out.contains("mp now: close-to-close daily pulse"));
+        assert!(out.contains("mp week: local journal week"));
+        assert!(out.contains("first matching Yahoo daily close"));
+        assert!(out.contains("session dates can differ"));
+    }
+
+    #[test]
+    fn static_equity_session_status_is_weekend_aware() {
+        assert!(static_equity_session_status(Some(1)).contains("weekday"));
+        assert!(static_equity_session_status(Some(5)).contains("weekday"));
+        assert!(static_equity_session_status(Some(6)).contains("weekend"));
+        assert!(static_equity_session_status(Some(7)).contains("weekend"));
+        assert!(static_equity_session_status(None).contains("unavailable"));
+    }
+
+    #[test]
+    fn calendar_output_avoids_trading_advice_language() {
+        let out = render_calendar().to_lowercase();
+        for forbidden in [
+            "buy",
+            "sell",
+            "price target",
+            "stop-loss",
+            "portfolio",
+            "매수",
+            "매도",
+            "손절",
+            "목표가",
+        ] {
+            assert!(
+                !out.contains(forbidden),
+                "calendar output should avoid advice term: {forbidden}"
+            );
+        }
     }
 
     #[test]
@@ -3518,6 +4514,20 @@ mod tests {
         assert!(out.contains("금리·달러"));
         assert!(out.contains("local journal only"));
         assert!(out.contains("not live research or trading advice"));
+    }
+
+    #[test]
+    fn find_renders_radar_and_fomo_snippets() {
+        let events = vec![
+            "{\"type\":\"radar\",\"timestamp\":\"2026-04-23T09:00:00+0900\",\"scenario\":\"Semis-led growth risk-on; watch BTC/KOSPI confirmation\",\"prompt\":\"Run mp think\"}".into(),
+            "{\"type\":\"fomo_check\",\"timestamp\":\"2026-04-23T09:05:00+0900\",\"scenario\":\"Semis-led growth risk-on; watch BTC/KOSPI confirmation\",\"prompt\":\"Run mp think\"}".into(),
+        ];
+        let out = render_find_from_events(&events, "/tmp/journal.jsonl", "Semis", "today".into());
+
+        assert!(out.contains("radars 1"));
+        assert!(out.contains("fomo 1"));
+        assert!(out.contains("radar · Semis-led growth"));
+        assert!(out.contains("fomo_check · Semis-led growth"));
     }
 
     #[test]
@@ -3619,6 +4629,299 @@ mod tests {
         assert!(rendered.contains("Basis"));
         assert!(rendered.contains("close-to-close pulse"));
         assert!(rendered.contains("not high/low gap, exact 24h, or weekly return"));
+    }
+
+    #[test]
+    fn pulse_renders_daily_decision_checklist_in_non_compact_output() {
+        let p = compose_cross_asset_test_pulse();
+        let rendered = render_pulse(&p, false);
+
+        assert_eq!(rendered.matches("Daily Decision Checklist").count(), 1);
+        for label in checklist_labels() {
+            assert!(rendered.contains(label), "missing {label}");
+        }
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_labels_stay_in_order() {
+        let p = compose_cross_asset_test_pulse();
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered);
+
+        assert_eq!(
+            checklist
+                .lines()
+                .filter(|line| line.starts_with("  "))
+                .count(),
+            6
+        );
+        let mut previous = 0;
+        for label in checklist_labels() {
+            assert_eq!(checklist.matches(label).count(), 1);
+            let current = checklist.find(label).expect("label should be present");
+            assert!(current >= previous, "{label} rendered out of order");
+            previous = current;
+        }
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_sits_between_seeds_and_source_notes() {
+        let mut p = compose_cross_asset_test_pulse();
+        p.notes = vec!["fixture quote source".into()];
+        let rendered = render_pulse(&p, false);
+
+        let seeds = rendered
+            .find("Market puzzle / question seeds")
+            .expect("question seeds should render");
+        let checklist = rendered
+            .find("Daily Decision Checklist")
+            .expect("checklist should render");
+        let notes = rendered
+            .find("Source notes")
+            .expect("source notes should render");
+
+        assert!(seeds < checklist);
+        assert!(checklist < notes);
+    }
+
+    #[test]
+    fn radar_renders_daily_context_and_fomo_checkpoint() {
+        let p = compose_cross_asset_test_pulse();
+        let checklist = daily_decision_checklist(&p);
+        let rendered = render_radar(&p, &checklist);
+
+        assert!(rendered.contains("Market Radar"));
+        assert!(rendered.contains("Scenario:"));
+        assert!(rendered.contains("Watch:"));
+        assert!(rendered.contains("Confirm:"));
+        assert!(rendered.contains("Falsify:"));
+        assert!(rendered.contains("FOMO checkpoint"));
+        assert!(rendered.contains("opportunity-cost fear"));
+        assert!(rendered.contains("Reasoning support only"));
+    }
+
+    #[test]
+    fn radar_output_avoids_trading_advice_language() {
+        let p = compose_cross_asset_test_pulse();
+        let checklist = daily_decision_checklist(&p);
+        let rendered = render_radar(&p, &checklist).to_lowercase();
+        for forbidden in [
+            "buy",
+            "sell",
+            "price target",
+            "stop-loss",
+            "portfolio",
+            "매수",
+            "매도",
+            "손절",
+            "목표가",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "radar output should avoid advice term: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn fomo_checkpoint_renders_linked_context_and_prompts() {
+        let checkpoint = FomoCheckpoint {
+            timestamp: "2026-04-23T10:00:00+0900".into(),
+            linked_pulse: Some("2026-04-23T09:55:00+0900".into()),
+            linked_radar: Some("2026-04-23T09:56:00+0900".into()),
+            scenario: Some("Semis-led growth risk-on; watch BTC/KOSPI confirmation".into()),
+            confirm: Some("Semis and Nasdaq keep leading while BTC and KOSPI confirm.".into()),
+            falsify: Some("Semis lose leadership first.".into()),
+            watch: Some("Semis vs Nasdaq, BTC, KOSPI, DXY, USD/KRW, and US 10Y.".into()),
+            prompt: FOMO_JOURNAL_PROMPT.into(),
+        };
+        let rendered = render_fomo_checkpoint(&checkpoint);
+
+        assert!(rendered.contains("FOMO Checkpoint"));
+        assert!(rendered.contains("Latest radar: 2026-04-23T09:56:00+0900"));
+        assert!(rendered.contains("Latest pulse: 2026-04-23T09:55:00+0900"));
+        assert!(rendered.contains("opportunity-cost fear"));
+        assert!(rendered.contains("Carry-over checks"));
+        assert!(rendered.contains("Next journal prompt"));
+        assert!(rendered.contains("Reasoning support only"));
+    }
+
+    #[test]
+    fn fomo_checkpoint_falls_back_without_prior_radar() {
+        let checkpoint = FomoCheckpoint {
+            timestamp: "2026-04-23T10:00:00+0900".into(),
+            linked_pulse: None,
+            linked_radar: None,
+            scenario: None,
+            confirm: None,
+            falsify: None,
+            watch: None,
+            prompt: FOMO_JOURNAL_PROMPT.into(),
+        };
+        let rendered = render_fomo_checkpoint(&checkpoint);
+
+        assert!(rendered.contains("Latest radar: not recorded yet"));
+        assert!(rendered.contains("run `mp watch`"));
+        assert!(!rendered.contains("Carry-over checks"));
+    }
+
+    #[test]
+    fn radar_and_fomo_json_are_reviewable_events() {
+        let p = compose_cross_asset_test_pulse();
+        let checklist = daily_decision_checklist(&p);
+        let radar = radar_json(&p, &checklist);
+        assert!(radar.contains("\"type\":\"radar\""));
+        assert!(radar.contains("\"linked_pulse_timestamp\""));
+        assert!(radar.contains("\"scenario\""));
+        assert!(radar.contains("\"prompt\""));
+
+        let checkpoint = FomoCheckpoint {
+            timestamp: "2026-04-23T10:00:00+0900".into(),
+            linked_pulse: Some("pulse-ts".into()),
+            linked_radar: Some("radar-ts".into()),
+            scenario: Some(checklist.scenario.into()),
+            confirm: Some(checklist.confirm.into()),
+            falsify: Some(checklist.falsify.into()),
+            watch: Some(checklist.watch.into()),
+            prompt: FOMO_JOURNAL_PROMPT.into(),
+        };
+        let fomo = fomo_check_json(&checkpoint);
+        assert!(fomo.contains("\"type\":\"fomo_check\""));
+        assert!(fomo.contains("\"linked_radar_timestamp\":\"radar-ts\""));
+        assert!(fomo.contains("\"linked_pulse_timestamp\":\"pulse-ts\""));
+        assert!(fomo.contains("\"scenario\""));
+    }
+
+    #[test]
+    fn pulse_compact_output_excludes_daily_decision_checklist() {
+        let p = compose_cross_asset_test_pulse();
+        let rendered = render_pulse(&p, true);
+
+        assert!(rendered.starts_with("[mp] "));
+        assert_eq!(rendered.lines().count(), 1);
+        assert!(rendered.contains(" · "));
+        assert!(rendered.contains("Puzzle: "));
+        assert!(!rendered.contains("Daily Decision Checklist"));
+        for label in checklist_labels() {
+            assert!(!rendered.contains(label), "compact output leaked {label}");
+        }
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_avoids_advice_language_and_unsupported_semis_claims() {
+        let p = compose_cross_asset_test_pulse();
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered).to_lowercase();
+
+        for forbidden in [
+            "buy",
+            "sell",
+            "price target",
+            "stop-loss",
+            "position size",
+            "portfolio",
+            "매수",
+            "매도",
+            "손절",
+            "비중",
+            "semis-led",
+            "semiconductor strength",
+        ] {
+            assert!(
+                !checklist.contains(forbidden),
+                "checklist should not contain {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_is_not_persisted_in_pulse_json() {
+        let p = compose_cross_asset_test_pulse();
+        let json = pulse_json(&p);
+
+        assert!(!json.contains("Daily Decision Checklist"));
+        assert!(!json.contains("Scenario"));
+        assert!(!json.contains("Confirm"));
+        assert!(!json.contains("Falsify"));
+        assert!(!json.contains("Discipline"));
+        assert!(!json.contains("Journal"));
+    }
+
+    #[test]
+    fn sox_proxy_is_pulse_only_not_shared_with_week_or_regime() {
+        assert!(!SYMBOLS.iter().any(|(symbol, _, _)| *symbol == "^SOX"));
+        assert_eq!(PULSE_ONLY_SYMBOLS, &[("^SOX", "Semis", "")]);
+
+        let week = render_week(&compose_test_week(compose_base_test_assets()), &[]);
+        let regime = render_regime(&compose_test_regime(compose_base_test_assets()));
+
+        assert!(!week.contains("Semis"));
+        assert!(!regime.contains("Semis"));
+    }
+
+    #[test]
+    fn pulse_renders_pulse_only_semis_asset_in_non_compact_output() {
+        let p = compose_semis_test_pulse(Some(2.0), 1.2, 0.7, 0.0);
+        let rendered = render_pulse(&p, false);
+
+        assert!(rendered.contains("  - Semis: 100.00 (+2.00%)"));
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_detects_semis_led_growth_without_macro_pressure() {
+        let p = compose_semis_test_pulse(Some(2.0), 1.2, 0.7, 0.0);
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered);
+
+        assert!(
+            checklist.contains("Scenario: Semis-led growth risk-on; watch BTC/KOSPI confirmation")
+        );
+        assert!(checklist.contains("Confirm: Semis and Nasdaq keep leading"));
+        assert!(checklist.contains("Watch: Semis vs Nasdaq"));
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_detects_semis_led_growth_with_macro_pressure() {
+        let p = compose_semis_test_pulse(Some(2.0), 1.2, 0.7, 0.8);
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered);
+
+        assert!(
+            checklist.contains("Scenario: Semis-led growth risk-on; macro confirmation incomplete")
+        );
+        assert!(checklist.contains("dollar/rates pressure stops rising"));
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_detects_weak_semis_when_available() {
+        let p = compose_semis_test_pulse(Some(-0.6), 1.2, 0.7, 0.0);
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered);
+
+        assert!(checklist.contains(
+            "Scenario: Growth leadership fading; watch whether semis or BTC breaks first"
+        ));
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_detects_nasdaq_without_semis_confirmation() {
+        let p = compose_semis_test_pulse(Some(0.2), 1.2, 0.7, 0.0);
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered);
+
+        assert!(
+            checklist.contains("Scenario: Nasdaq risk-on with semis confirmation still pending")
+        );
+    }
+
+    #[test]
+    fn pulse_daily_decision_checklist_does_not_claim_semis_leadership_without_semis_change() {
+        let p = compose_semis_test_pulse(None, 1.2, 0.7, 0.0);
+        let rendered = render_pulse(&p, false);
+        let checklist = checklist_section(&rendered).to_lowercase();
+
+        assert!(!checklist.contains("semis-led"));
+        assert!(!checklist.contains("semiconductor leadership"));
     }
 
     #[test]
@@ -3764,6 +5067,129 @@ mod tests {
         assert!(rendered.contains("rename this week"));
         assert!(rendered.contains("rates"));
         assert!(rendered.contains("not investment advice"));
+    }
+
+    fn compose_base_test_assets() -> Vec<Asset> {
+        vec![
+            Asset {
+                symbol: "^GSPC",
+                label: "S&P 500",
+                unit: "",
+                value: Some(100.0),
+                change: Some(1.2),
+                note: None,
+            },
+            Asset {
+                symbol: "^IXIC",
+                label: "Nasdaq",
+                unit: "",
+                value: Some(100.0),
+                change: Some(2.0),
+                note: None,
+            },
+            Asset {
+                symbol: "^KS11",
+                label: "KOSPI",
+                unit: "",
+                value: Some(100.0),
+                change: Some(0.8),
+                note: None,
+            },
+            Asset {
+                symbol: "KRW=X",
+                label: "USD/KRW",
+                unit: "KRW",
+                value: Some(1400.0),
+                change: Some(0.2),
+                note: None,
+            },
+            Asset {
+                symbol: "DX-Y.NYB",
+                label: "DXY",
+                unit: "",
+                value: Some(105.0),
+                change: Some(0.3),
+                note: None,
+            },
+            Asset {
+                symbol: "^TNX",
+                label: "US 10Y",
+                unit: "%",
+                value: Some(4.8),
+                change: Some(0.8),
+                note: None,
+            },
+            Asset {
+                symbol: "CL=F",
+                label: "WTI",
+                unit: "USD",
+                value: Some(70.0),
+                change: Some(1.2),
+                note: None,
+            },
+            Asset {
+                symbol: "BTC-USD",
+                label: "BTC",
+                unit: "USD",
+                value: Some(100000.0),
+                change: Some(3.0),
+                note: None,
+            },
+        ]
+    }
+
+    fn compose_cross_asset_test_pulse() -> Pulse {
+        compose_test_pulse(compose_base_test_assets())
+    }
+
+    fn compose_semis_test_pulse(
+        semis_change: Option<f64>,
+        nasdaq_change: f64,
+        spx_change: f64,
+        rates_change: f64,
+    ) -> Pulse {
+        let mut assets = compose_base_test_assets();
+        for asset in &mut assets {
+            match asset.symbol {
+                "^GSPC" => asset.change = Some(spx_change),
+                "^IXIC" => asset.change = Some(nasdaq_change),
+                "^TNX" => asset.change = Some(rates_change),
+                "KRW=X" | "DX-Y.NYB" | "CL=F" => asset.change = Some(0.0),
+                "^KS11" => asset.change = Some(0.8),
+                "BTC-USD" => asset.change = Some(2.0),
+                _ => {}
+            }
+        }
+        assets.push(Asset {
+            symbol: "^SOX",
+            label: "Semis",
+            unit: "",
+            value: Some(100.0),
+            change: semis_change,
+            note: None,
+        });
+        compose_test_pulse(assets)
+    }
+
+    fn checklist_labels() -> [&'static str; 6] {
+        [
+            "  Scenario:",
+            "  Confirm:",
+            "  Falsify:",
+            "  Watch:",
+            "  Discipline:",
+            "  Journal:",
+        ]
+    }
+
+    fn checklist_section(rendered: &str) -> &str {
+        rendered
+            .split("Daily Decision Checklist")
+            .nth(1)
+            .expect("checklist section should render")
+            .split("\nSource notes")
+            .next()
+            .expect("checklist section should be split from notes")
     }
 
     fn compose_test_pulse(assets: Vec<Asset>) -> Pulse {


### PR DESCRIPTION
## Summary

- Add `mp watch` Daily Radar cards for same-day scenario / watch / confirm / falsify context.
- Add `mp fomo` checkpoints that link to the latest radar/pulse context and preserve the evidence-vs-opportunity-cost-fear pause flow.
- Persist `radar` and `fomo_check` JSONL events and include them in `mp review` / `mp find` counts and recall snippets.
- Update README, MVP docs, and Codex/Claude adapters for the new terminal-only flow.

## Product boundary

- Terminal-only v1: no daemon, OS push, external messenger, paid API, or GUI.
- Reasoning support only: no trading instructions, recommendations, price targets, stop-loss, or portfolio guidance.

## Verification

- `cargo fmt`
- `cargo check --quiet`
- `cargo test --quiet` — 81 passed
- `cargo clippy --quiet -- -D warnings`
- `git diff --check`
- Temp `MARKET_PULSE_HOME` smoke:
  - `mp help` includes `mp watch` / `mp fomo`
  - `mp watch --no-save` renders Market Radar + FOMO checkpoint boundary
  - `mp fomo --no-save` renders FOMO Checkpoint boundary

## Notes

- `watch` and `fomo` are now reserved command words. Plain inquiry text can still use `mp ask watch` / `mp ask fomo`.
