### PR TITLE
Clarify mp research no-provider contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ evidence/source marker such as `리서치`, `근거`, `출처`, `왜`, `뉴스`,
 
 ### `mp research "question"` / `mp "question" --research`
 
-Research mode keeps the source-backed inquiry contract without
-making built-in network/news providers mandatory yet:
+Research mode has an explicit source contract: it is source-backed only when a
+provider bridge supplies source metadata. Without a configured provider it
+prints an unavailable/no-provider state and a reasoning scaffold instead of
+presenting the output as completed research.
 
 ```bash
 mp research "금리 하락이 성장주에 좋은 신호임?"
@@ -114,7 +116,7 @@ mp "대형 IPO 때문에 성장주가 강한 걸까?" --research
 Output includes:
 
 - provider/source metadata section
-- clear no-provider fallback when no live source is configured
+- clear `Research unavailable` / no-provider state when no live source is configured
 - distinction between source-backed material and inference scaffolding
 - evidence against / counter-view
 - data to check next

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,12 +22,12 @@ Codex/Claude adapters -> mp Rust binary -> quote + local inquiry/research lenses
 Initial code may keep these simple, but the boundaries should stay visible:
 
 - source hooks: quotes, RSS, macro data, filings
-- research provider hooks: noop fallback now, optional
+- research provider hooks: explicit no-provider/unavailable fallback now, optional
   `MARKET_PULSE_SEARCH_CMD` JSONL bridge, `adapters/search-command/` fixture
   kit, RSS/search/API providers later
 - lens hooks: risk-on/off, rates vs growth, dollar liquidity, Korea market, AI/semis, IPO/event, positioning/flow
 - inquiry hooks: question breakdown, possible explanations, evidence checks, counter-view, next better question
-- research inquiry hooks: source metadata, source-backed claims, no-source fallback, data-to-check prompts
+- research inquiry hooks: source metadata, source-backed claims, no-provider/unavailable fallback, data-to-check prompts
 - weekly hooks: current-local-week market story, current-week journal summary, next-week check questions
 - calendar hooks: local-date windows for today/yesterday/this-week/last-week and explicit review shortcuts
 - recall hooks: local journal full-text search, date/window filters, match snippets, recurring themes, next recall question
@@ -49,7 +49,7 @@ Planned or current adapters:
 
 ## Dependency stance
 
-The MVP intentionally avoids Rust crate dependencies. It uses the standard library plus a `curl` subprocess for quote fetches. Research mode proves the provider boundary with deterministic noop behavior and an opt-in external command bridge rather than making network providers mandatory. Add HTTP/JSON crates only when source reliability, parsing complexity, or provider abstraction becomes the actual bottleneck.
+The MVP intentionally avoids Rust crate dependencies. It uses the standard library plus a `curl` subprocess for quote fetches. Research mode proves the provider boundary with explicit no-provider/unavailable behavior and an opt-in external command bridge rather than making network providers mandatory. Add HTTP/JSON crates only when source reliability, parsing complexity, or provider abstraction becomes the actual bottleneck.
 
 `MARKET_PULSE_SEARCH_CMD` is a restricted bridge for local search tooling: the template must contain `{query}`, it is parsed into argv with simple quote-aware grouping, executed without a shell, capped by a 5 second timeout, and limited to the first 20 non-empty JSONL rows. JSON string escapes are decoded before rendering.
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -24,11 +24,11 @@ Acceptance criteria:
 
 Acceptance criteria:
 
-- Routes both the explicit subcommand and `--research` flag to research-backed inquiry mode.
-- Uses a `ResearchProvider`-style boundary with deterministic noop behavior when no provider is configured.
+- Routes both the explicit subcommand and `--research` flag to research mode.
+- Uses a `ResearchProvider`-style boundary with deterministic no-provider/unavailable behavior when no provider is configured.
 - Supports an opt-in `MARKET_PULSE_SEARCH_CMD` external command hook for JSONL source metadata.
 - Executes the search hook without a shell, with quote-aware argv parsing, `{query}` substitution, a 5 second timeout, and at most 20 JSONL rows parsed.
-- Falls back to inference scaffolding if the hook is unset, invalid, times out, exits non-zero, or returns no valid source rows.
+- Renders `Research unavailable` plus inference scaffolding if the hook is unset, invalid, times out, exits non-zero, or returns no valid source rows; no-source output must not masquerade as source-backed research.
 - Renders source metadata when available, including decoded JSON string escapes.
 - Renders a clear no-provider/no-source fallback when no live provider is configured.
 - Distinguishes source-backed material from inference scaffolding.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -24,8 +24,9 @@ mp "시장 질문" --research
 ```
 
 Research mode keeps the same learning loop, but adds an explicit source boundary:
-show sources when a provider supplies them, otherwise say clearly that the answer
-is inference scaffolding and list what data should be checked next. The current
+show sources when a provider supplies them, otherwise render a clear
+`Research unavailable` / no-provider state, say that the answer is inference
+scaffolding, and list what data should be checked next. The current
 bridge is intentionally opt-in: `MARKET_PULSE_SEARCH_CMD` can attach local search
 tooling that emits JSONL source metadata, while the core remains CLI-first and
 provider-agnostic.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2864,8 +2864,14 @@ fn render_inquiry(i: &Inquiry) -> String {
 }
 
 fn render_research_inquiry(i: &Inquiry, bundle: &ResearchBundle) -> String {
+    let source_backed = !bundle.sources.is_empty();
+    let heading = if source_backed {
+        "Source-backed Research Inquiry"
+    } else {
+        "Research unavailable"
+    };
     let mut out = format!(
-        "Research-backed Inquiry · {} · provider: {}\n\nQuestion breakdown\n",
+        "{heading} · {} · provider: {}\n\nQuestion breakdown\n",
         i.timestamp, bundle.provider
     );
     for x in &i.breakdown {
@@ -2873,10 +2879,9 @@ fn render_research_inquiry(i: &Inquiry, bundle: &ResearchBundle) -> String {
     }
     out.push_str("\nSources checked\n");
     if bundle.sources.is_empty() {
-        out.push_str("  - No configured research source returned metadata.\n");
-        out.push_str(
-            "  - Treat the analysis below as inference scaffolding, not source-backed fact.\n",
-        );
+        out.push_str("  - Source-backed research is unavailable: no configured provider returned source metadata.\n");
+        out.push_str("  - Configure MARKET_PULSE_SEARCH_CMD with a JSONL source bridge for source-backed research.\n");
+        out.push_str("  - Treat the analysis below as inference scaffolding only, not source-backed fact.\n");
     } else {
         for (idx, source) in bundle.sources.iter().enumerate() {
             let published = source
@@ -2903,7 +2908,7 @@ fn render_research_inquiry(i: &Inquiry, bundle: &ResearchBundle) -> String {
     }
     out.push_str("\nWhat the sources suggest\n");
     if bundle.sources.is_empty() {
-        out.push_str("  - No source-backed claim yet; use the inquiry lens below to decide what evidence to fetch next.\n");
+        out.push_str("  - Source-backed research is unavailable in this run; use the inquiry lens below to decide what evidence to fetch next.\n");
     } else {
         for source in &bundle.sources {
             out.push_str(&format!("  - Source-backed: {}\n", source.evidence));
@@ -4512,7 +4517,7 @@ mod tests {
     }
 
     #[test]
-    fn research_output_renders_no_provider_fallback_and_boundary() {
+    fn research_output_renders_no_provider_unavailable_and_boundary() {
         let inquiry = make_inquiry("금리 하락이 성장주에 좋은 신호임?", None);
         let query = ResearchQuery {
             question: inquiry.question.clone(),
@@ -4521,10 +4526,11 @@ mod tests {
         let bundle = research_bundle_from_provider(&NoopResearchProvider, &query);
         let out = render_research_inquiry(&inquiry, &bundle);
         for section in [
-            "Research-backed Inquiry",
+            "Research unavailable",
             "Sources checked",
-            "No configured research source",
-            "inference scaffolding",
+            "Source-backed research is unavailable",
+            "MARKET_PULSE_SEARCH_CMD",
+            "inference scaffolding only",
             "What the sources suggest",
             "Evidence against / counter-view",
             "Data to check next",
@@ -4533,6 +4539,7 @@ mod tests {
         ] {
             assert!(out.contains(section), "missing section: {section}");
         }
+        assert!(!out.contains("Research-backed Inquiry"));
         assert_eq!(bundle.sources.len(), 0);
     }
 
@@ -4546,6 +4553,8 @@ mod tests {
         assert!(out.contains("fixture://ipo-calendar"));
         assert!(out.contains("Relevance: event timing"));
         assert!(out.contains("Source-backed:"));
+        assert!(out.contains("Source-backed Research Inquiry"));
+        assert!(!out.contains("Research unavailable"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reserve source-backed research labeling for runs with provider source metadata
- Render provider-less research as `Research unavailable` with `MARKET_PULSE_SEARCH_CMD` setup guidance
- Update docs/tests to lock the no-provider vs source-backed contract

## Verification
- `cargo test` on staged PR tree: 92 passed, 0 failed
- Full working tree `cargo test`: 100 passed, 0 failed
- CLI smoke: no-provider renders `Research unavailable`; fixture provider renders `Source-backed Research Inquiry`
- Architect review: APPROVED

## Notes
- Existing local earnings changes remain uncommitted and are intentionally excluded from this PR.